### PR TITLE
Allow BlockscoreError to initialize when json_body passed in is empty

### DIFF
--- a/lib/blockscore/error/blockscore_error.rb
+++ b/lib/blockscore/error/blockscore_error.rb
@@ -6,10 +6,11 @@ module BlockScore
     attr_reader :http_status
     attr_reader :json_body
 
-    def initialize(message=nil, json_body=nil, http_status="400",
+    def initialize(message=nil, json_body={}, http_status="400",
                     error_type="invalid_request_error")
       super(message)
 
+      json_body["error"] ||= {}
       message_desc = "#{json_body["error"]["param"]} #{json_body["error"]["code"]}"
 
       @error_type = error_type 


### PR DESCRIPTION
I ran into a weird problem and traced it to here. There was a blockscore error, and then there was an error in blockscore trying to initialize the error.

`undefined method '[]' for nil:NilClass` used to result from `message_desc ="..."` because by default json_body was nil. Now it is defaulting to an empty hash, and I ensure that hash has the `"error"` key.

It would be great if this could find it's way into a 3.0.X release as well as the latest 4.0.X release :)