### PR TITLE
Fix bug in readme example for creating person

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ person = BlockScore::Person.create(
   address_street1: '1 Infinite Loop',
   address_street2: 'Apt 6',
   address_city: 'Cupertino',
-  address_state: 'CA',
+  address_subdivision: 'CA',
   address_postal_code: '95014',
   address_country_code: 'US'
 )


### PR DESCRIPTION
Hey guys - as I was integrating I noticed this bug. Naming that key `address_state` makes the create command return a 400 error from your server.