### PR TITLE
Update 40

### DIFF
--- a/lib/blockscore/actions/update.rb
+++ b/lib/blockscore/actions/update.rb
@@ -13,6 +13,11 @@ module BlockScore
     #  foo.name_first = 'John'
     #  foo.save
     #  # => true
+    #
+    #  foo = Foo.new(name_first: 'John')
+    #  foo.update(name_first: 'Jane')
+    #  foo.name_first
+    #  # => 'Jane'
     module Update
       extend Forwardable
 
@@ -46,7 +51,7 @@ module BlockScore
 
       def update!(params)
         response = patch(update_url, params)
-        initialize_from(response.attributes)
+        self.attributes = response.attributes
       end
 
       # Filters out the non-updateable params.

--- a/lib/blockscore/actions/update.rb
+++ b/lib/blockscore/actions/update.rb
@@ -27,19 +27,38 @@ module BlockScore
 
       def_delegators 'self.class', :endpoint, :patch
 
+      # May be deprecated in future releases, prefer :update.
       def save!
         if persisted?
-          patch("#{endpoint}/#{id}", filter_params)
+          patch(update_url, filter_params)
           true
         else
           super
         end
       end
 
+      def update(params)
+        update!(params)
+        true
+      rescue
+        false
+      end
+
+      def update!(params)
+        response = patch(update_url, params)
+        initialize_from(response.attributes)
+      end
+
       # Filters out the non-updateable params.
       def filter_params
         # Cannot %i syntax, not introduced until Ruby 2.0.0
         attributes.reject { |key, _| PERSISTENT_ATTRIBUTES.include?(key) }
+      end
+
+      private
+      
+      def update_url
+        "#{endpoint}/#{id}"    
       end
     end
   end

--- a/lib/blockscore/actions/update.rb
+++ b/lib/blockscore/actions/update.rb
@@ -32,7 +32,6 @@ module BlockScore
 
       def_delegators 'self.class', :endpoint, :patch
 
-      # May be deprecated in future releases, prefer :update.
       def save!
         if persisted?
           patch(update_url, filter_params)

--- a/lib/blockscore/base.rb
+++ b/lib/blockscore/base.rb
@@ -90,10 +90,10 @@ module BlockScore
       end
     end
 
-    # Reinitializes an object based on a hash of values.
-    def initialize_from(values)
-      @attributes = values
-    end
+    # Allow reinitialization of an object's attributes. In the future, if
+    # more work is done during reinitialization, may want to break this out
+    # into a :initialize_from method.
+    attr_writer :attributes
 
     private
 

--- a/lib/blockscore/base.rb
+++ b/lib/blockscore/base.rb
@@ -90,6 +90,11 @@ module BlockScore
       end
     end
 
+    # Reinitializes an object based on a hash of values.
+    def initialize_from(values)
+      @attributes = values
+    end
+
     private
 
     def method_missing(method, *args, &block)

--- a/lib/blockscore/base.rb
+++ b/lib/blockscore/base.rb
@@ -90,9 +90,6 @@ module BlockScore
       end
     end
 
-    # Allow reinitialization of an object's attributes. In the future, if
-    # more work is done during reinitialization, may want to break this out
-    # into a :initialize_from method.
     attr_writer :attributes
 
     private

--- a/lib/blockscore/version.rb
+++ b/lib/blockscore/version.rb
@@ -1,3 +1,3 @@
 module BlockScore
-  VERSION = '4.2.1'.freeze
+  VERSION = '4.3.0'.freeze
 end

--- a/spec/cassettes/block_score/candidate/update.yml
+++ b/spec/cassettes/block_score/candidate/update.yml
@@ -1,0 +1,116 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://BLOCKSCORE_TEST_KEY:@api.blockscore.com/candidates
+    body:
+      encoding: UTF-8
+      string: '{"ssn":"0000","date_of_birth":"1988-07-26","name_first":"John","name_last":"Gorczany","address_street1":"4788
+        Jerrell Port","address_city":"New Stoneshire","address_country_code":"CH"}'
+    headers:
+      Accept:
+      - application/vnd.blockscore+json;version=4
+      User-Agent:
+      - blockscore-ruby/4.2.1 (https://github.com/BlockScore/blockscore-ruby)
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Server:
+      - Cowboy
+      Connection:
+      - keep-alive
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"5e017096a6446afb3e4811f32719fd2f"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 1b4a4e7d-ebb4-4724-9c7d-997cd9758ade
+      X-Runtime:
+      - '0.041767'
+      Strict-Transport-Security:
+      - max-age=31536000
+      Date:
+      - Sat, 09 Jan 2016 03:24:38 GMT
+      X-Rack-Cache:
+      - invalidate, pass
+      Set-Cookie:
+      - __profilin=p%3Dt; path=/
+      Transfer-Encoding:
+      - chunked
+      Via:
+      - 1.1 vegur
+    body:
+      encoding: UTF-8
+      string: '{"object":"candidate","id":"56907d76333764000300030e","created_at":1452309878,"updated_at":1452309878,"livemode":false,"note":null,"ssn":"0000","passport":null,"date_of_birth":"1988-07-26","name_first":"John","name_middle":null,"name_last":"Gorczany","address_street1":"4788
+        Jerrell Port","address_street2":null,"address_city":"New Stoneshire","address_subdivision":null,"address_postal_code":null,"address_country_code":"CH"}'
+    http_version: 
+  recorded_at: Sat, 09 Jan 2016 03:24:38 GMT
+- request:
+    method: patch
+    uri: https://BLOCKSCORE_TEST_KEY:@api.blockscore.com/candidates/56907d76333764000300030e
+    body:
+      encoding: UTF-8
+      string: '{"name_first":"Jane"}'
+    headers:
+      Accept:
+      - application/vnd.blockscore+json;version=4
+      User-Agent:
+      - blockscore-ruby/4.2.1 (https://github.com/BlockScore/blockscore-ruby)
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Cowboy
+      Connection:
+      - keep-alive
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"9e5b34483f0d76e7f6d0d196c865db48"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - a8dca8bb-310e-4d67-8e70-2c4900c6d502
+      X-Runtime:
+      - '0.024184'
+      Strict-Transport-Security:
+      - max-age=31536000
+      Date:
+      - Sat, 09 Jan 2016 03:24:38 GMT
+      X-Rack-Cache:
+      - invalidate, pass
+      Set-Cookie:
+      - __profilin=p%3Dt; path=/
+      Transfer-Encoding:
+      - chunked
+      Via:
+      - 1.1 vegur
+    body:
+      encoding: UTF-8
+      string: '{"object":"candidate","id":"56907d76333764000300030e","created_at":1452309878,"updated_at":1452309878,"livemode":false,"note":null,"ssn":"0000","passport":null,"date_of_birth":"1988-07-26","name_first":"Jane","name_middle":null,"name_last":"Gorczany","address_street1":"4788
+        Jerrell Port","address_street2":null,"address_city":"New Stoneshire","address_subdivision":null,"address_postal_code":null,"address_country_code":"CH"}'
+    http_version: 
+  recorded_at: Sat, 09 Jan 2016 03:24:38 GMT
+recorded_with: VCR 3.0.1

--- a/spec/cassettes/block_score/candidate/update/name_first.yml
+++ b/spec/cassettes/block_score/candidate/update/name_first.yml
@@ -1,0 +1,116 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://BLOCKSCORE_TEST_KEY:@api.blockscore.com/candidates
+    body:
+      encoding: UTF-8
+      string: '{"ssn":"0000","date_of_birth":"1935-09-16","name_first":"John","name_last":"Lind","address_street1":"6376
+        Bruen Hills","address_city":"Port Shane","address_country_code":"LT"}'
+    headers:
+      Accept:
+      - application/vnd.blockscore+json;version=4
+      User-Agent:
+      - blockscore-ruby/4.2.1 (https://github.com/BlockScore/blockscore-ruby)
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Server:
+      - Cowboy
+      Connection:
+      - keep-alive
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"2444e84e509eb03d782c2a3461cdf604"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 55332395-c56f-4f71-bc82-819b45398455
+      X-Runtime:
+      - '0.039426'
+      Strict-Transport-Security:
+      - max-age=31536000
+      Date:
+      - Sat, 09 Jan 2016 03:24:39 GMT
+      X-Rack-Cache:
+      - invalidate, pass
+      Set-Cookie:
+      - __profilin=p%3Dt; path=/
+      Transfer-Encoding:
+      - chunked
+      Via:
+      - 1.1 vegur
+    body:
+      encoding: UTF-8
+      string: '{"object":"candidate","id":"56907d77333764000300030f","created_at":1452309879,"updated_at":1452309879,"livemode":false,"note":null,"ssn":"0000","passport":null,"date_of_birth":"1935-09-16","name_first":"John","name_middle":null,"name_last":"Lind","address_street1":"6376
+        Bruen Hills","address_street2":null,"address_city":"Port Shane","address_subdivision":null,"address_postal_code":null,"address_country_code":"LT"}'
+    http_version: 
+  recorded_at: Sat, 09 Jan 2016 03:24:39 GMT
+- request:
+    method: patch
+    uri: https://BLOCKSCORE_TEST_KEY:@api.blockscore.com/candidates/56907d77333764000300030f
+    body:
+      encoding: UTF-8
+      string: '{"name_first":"Jane"}'
+    headers:
+      Accept:
+      - application/vnd.blockscore+json;version=4
+      User-Agent:
+      - blockscore-ruby/4.2.1 (https://github.com/BlockScore/blockscore-ruby)
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Cowboy
+      Connection:
+      - keep-alive
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"c131a94a47916aa7a8227a41e49919c7"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 2ba2e7d3-7fab-450f-a9ac-92604ca82651
+      X-Runtime:
+      - '0.023023'
+      Strict-Transport-Security:
+      - max-age=31536000
+      Date:
+      - Sat, 09 Jan 2016 03:24:39 GMT
+      X-Rack-Cache:
+      - invalidate, pass
+      Set-Cookie:
+      - __profilin=p%3Dt; path=/
+      Transfer-Encoding:
+      - chunked
+      Via:
+      - 1.1 vegur
+    body:
+      encoding: UTF-8
+      string: '{"object":"candidate","id":"56907d77333764000300030f","created_at":1452309879,"updated_at":1452309879,"livemode":false,"note":null,"ssn":"0000","passport":null,"date_of_birth":"1935-09-16","name_first":"Jane","name_middle":null,"name_last":"Lind","address_street1":"6376
+        Bruen Hills","address_street2":null,"address_city":"Port Shane","address_subdivision":null,"address_postal_code":null,"address_country_code":"LT"}'
+    http_version: 
+  recorded_at: Sat, 09 Jan 2016 03:24:39 GMT
+recorded_with: VCR 3.0.1

--- a/spec/unit/blockscore/candidate_spec.rb
+++ b/spec/unit/blockscore/candidate_spec.rb
@@ -108,7 +108,7 @@ module BlockScore
       it { is_expected.to match(/^#<BlockScore::Candidate:0x/) }
     end
 
-    pending '#update' do
+    describe '#update' do
       subject(:candidate) { create(:candidate, name_first: 'John') }
       before do
         candidate.update(name_first: 'Jane')


### PR DESCRIPTION
Adds an `:update` method to `BlockScore::Base` to add more of an `ActiveRecord` feel to the library.

In addition to the `:update` method, a protected `:initialize_from` method was added. This method will reinitialize the attributes of a given object from a provided values hash. The Stripe version of this
method updates the dynamically defined accessors and getters based on the values have changed. I have not done that because I do not think the value of an attribute changing is a positive signal as to whether or not a getter/setter will be called for that attribute in the future.

Also adds VCR cassettes for the update action, and changes the relevant spec from pending to active.

Fixes #40.

Bump version to 4.3.0 (Omit this commit if desired)

Minor version change due to addition of backwards compatible `:update` method.