### PR TITLE
allow overriding the api key

### DIFF
--- a/lib/blockscore/connection.rb
+++ b/lib/blockscore/connection.rb
@@ -27,10 +27,11 @@ module BlockScore
     end
 
     def request(method, path, params)
-      fail NoAPIKeyError, 'No API key was provided.' unless BlockScore.api_key
+      api_key = params.delete(:api_key) || BlockScore.api_key
+      fail NoAPIKeyError, 'No API key was provided.' unless api_key
 
       begin
-        response = execute_request(method, path, params)
+        response = execute_request(method, path, params, api_key)
       rescue SocketError, Errno::ECONNREFUSED => e
         raise APIConnectionError, e.message
       end
@@ -38,8 +39,8 @@ module BlockScore
       Response.handle_response(resource, response)
     end
 
-    def execute_request(method, path, params)
-      auth = { username: BlockScore.api_key, password: '' }
+    def execute_request(method, path, params, api_key)
+      auth = { username: api_key, password: '' }
 
       if method == :get
         path = encode_path_params(path, params)

--- a/spec/unit/blockscore/connection_spec.rb
+++ b/spec/unit/blockscore/connection_spec.rb
@@ -1,6 +1,5 @@
 module BlockScore
   RSpec.describe Connection do
-
     class ConnectionObject
       include BlockScore::Connection
 
@@ -14,39 +13,37 @@ module BlockScore
     let(:api_key) { BlockScore.api_key }
 
     before do
+      ua = "blockscore-ruby/#{BlockScore::VERSION} (https://github.com/BlockScore/blockscore-ruby)"
       expect(HTTParty).to receive(:send).with(
         :get,
-        "/foo?",
-        {
-          basic_auth: {
-            username: api_key,
-            password: ""
-          },
-          headers: {
-            "Accept" => "application/vnd.blockscore+json;version=4",
-            "User-Agent" => "blockscore-ruby/#{BlockScore::VERSION} (https://github.com/BlockScore/blockscore-ruby)",
-            "Content-Type" => "application/json"
-          },
-          body: nil
-        })
+        '/foo?',
+        basic_auth: {
+          username: api_key,
+          password: ''
+        },
+        headers: {
+          'Accept' => 'application/vnd.blockscore+json;version=4',
+          'User-Agent' => ua,
+          'Content-Type' => 'application/json'
+        },
+        body: nil
+      )
 
       expect(BlockScore::Response).to receive(:handle_response)
     end
 
-    describe "overriding API key" do
+    describe 'overriding API key' do
       let(:api_key) { "bar" }
 
-      it "uses the param" do
-        connector.get("/foo", { api_key: api_key })
+      it 'uses the param' do
+        connector.get('/foo', api_key: api_key)
       end
     end
 
-    describe "using the global API key" do
-      it "uses the param" do
-        connector.get("/foo", {})
+    describe 'using the global API key' do
+      it 'uses the param' do
+        connector.get('/foo', {})
       end
     end
-
-
   end
 end

--- a/spec/unit/blockscore/connection_spec.rb
+++ b/spec/unit/blockscore/connection_spec.rb
@@ -1,0 +1,52 @@
+module BlockScore
+  RSpec.describe Connection do
+
+    class ConnectionObject
+      include BlockScore::Connection
+
+      def resource # an unspoken contract.
+        nil
+      end
+    end
+
+    let(:connector) { ConnectionObject.new }
+
+    let(:api_key) { BlockScore.api_key }
+
+    before do
+      expect(HTTParty).to receive(:send).with(
+        :get,
+        "/foo?",
+        {
+          basic_auth: {
+            username: api_key,
+            password: ""
+          },
+          headers: {
+            "Accept" => "application/vnd.blockscore+json;version=4",
+            "User-Agent" => "blockscore-ruby/#{BlockScore::VERSION} (https://github.com/BlockScore/blockscore-ruby)",
+            "Content-Type" => "application/json"
+          },
+          body: nil
+        })
+
+      expect(BlockScore::Response).to receive(:handle_response)
+    end
+
+    describe "overriding API key" do
+      let(:api_key) { "bar" }
+
+      it "uses the param" do
+        connector.get("/foo", { api_key: api_key })
+      end
+    end
+
+    describe "using the global API key" do
+      it "uses the param" do
+        connector.get("/foo", {})
+      end
+    end
+
+
+  end
+end


### PR DESCRIPTION
Hello,

One requirement of a system I'm working on is being able to use test/prod at the same time (on the same Rails environment/server/process/what-have-you). GIven BlockScore's api key is currently a global, that's not possible using the client. 

My proposal here is pretty minimal - just allow overriding the api key on a given request. This is backwards compatible by default and wouldn't impact existing uses of the client.

Let me know your thoughts!