### PR TITLE
Deny nil retrieve argument

### DIFF
--- a/lib/blockscore/actions/retrieve.rb
+++ b/lib/blockscore/actions/retrieve.rb
@@ -11,8 +11,12 @@ module BlockScore
     # => #<BlockScore::Person:0x007fe39c424410>
     module Retrieve
       module ClassMethods
+
+        RESOURCE_ID_FORMAT = /\A[a-f0-9]+\z/.freeze
+
         def retrieve(id, options = {})
           fail ArgumentError, 'ID must be supplied' if id.nil? || id.empty?
+          fail ArgumentError, 'ID is malformed' unless id =~ RESOURCE_ID_FORMAT
           req = ->() { get("#{endpoint}/#{id}", options) }
           new(id: id, &req)
         end

--- a/lib/blockscore/actions/retrieve.rb
+++ b/lib/blockscore/actions/retrieve.rb
@@ -12,7 +12,7 @@ module BlockScore
     module Retrieve
       module ClassMethods
         def retrieve(id, options = {})
-          fail ArgumentError if id.empty?
+          fail ArgumentError, 'ID must be supplied' if id.nil? || id.empty?
           req = ->() { get("#{endpoint}/#{id}", options) }
           new(id: id, &req)
         end

--- a/spec/cassettes/block_score/not_found_error/behaves_like_an_error.yml
+++ b/spec/cassettes/block_score/not_found_error/behaves_like_an_error.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://BLOCKSCORE_TEST_KEY:@api.blockscore.com/people/invalid_id
+    uri: https://BLOCKSCORE_TEST_KEY:@api.blockscore.com/people/abc123
     body:
       encoding: US-ASCII
       string: ''
@@ -51,7 +51,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"error":{"type":"invalid_request_error","message":"Person with id
-        invalid_id could not be found"}}'
+        abc123 could not be found"}}'
     http_version: 
   recorded_at: Fri, 18 Sep 2015 17:11:51 GMT
 recorded_with: VCR 2.9.3

--- a/spec/unit/blockscore/errors/api_connection_error_spec.rb
+++ b/spec/unit/blockscore/errors/api_connection_error_spec.rb
@@ -1,9 +1,9 @@
 module BlockScore
   RSpec.describe APIConnectionError do
-    let(:stubbed_route_pattern) { %r(.*api\.blockscore\.com/people/connection_refused) }
+    let(:stubbed_route_pattern) { %r(.*api\.blockscore\.com/people/abc123) }
     let(:stubbed_error) { Errno::ECONNREFUSED }
     let(:message) { 'Connection refused - Exception from WebMock' }
-    subject { -> { BlockScore::Person.retrieve('connection_refused') } }
+    subject { -> { BlockScore::Person.retrieve('abc123') } }
 
     before { stub_request(:get, stubbed_route_pattern).to_raise(stubbed_error) }
 

--- a/spec/unit/blockscore/errors/not_found_error_spec.rb
+++ b/spec/unit/blockscore/errors/not_found_error_spec.rb
@@ -1,6 +1,6 @@
 module BlockScore
   RSpec.describe NotFoundError do
-    subject { -> { BlockScore::Person.retrieve('invalid_id') } }
+    subject { -> { BlockScore::Person.retrieve('abc123') } }
 
     it_behaves_like 'an error'
   end

--- a/spec/unit/blockscore/person_spec.rb
+++ b/spec/unit/blockscore/person_spec.rb
@@ -46,6 +46,17 @@ module BlockScore
       it { is_expected.to be_persisted }
       its(:name_first) { is_expected.not_to be_empty }
       its(:class) { should be BlockScore::Person }
+      context 'null id presented' do
+        let(:person_id) { nil }
+
+        it { expect { BlockScore::Person.retrieve(person_id) }.to raise_error(ArgumentError, 'ID must be supplied') }
+      end
+
+      context 'empty id presented' do
+        let(:person_id) { '' }
+
+        it { expect { BlockScore::Person.retrieve(person_id) }.to raise_error(ArgumentError, 'ID must be supplied') }
+      end
     end
 
     describe '.all' do

--- a/spec/unit/blockscore/person_spec.rb
+++ b/spec/unit/blockscore/person_spec.rb
@@ -57,6 +57,12 @@ module BlockScore
 
         it { expect { BlockScore::Person.retrieve(person_id) }.to raise_error(ArgumentError, 'ID must be supplied') }
       end
+
+      context 'Malformed ID presented' do
+        let(:person_id) { 'ABC&&234' }
+
+        it { expect { BlockScore::Person.retrieve(person_id) }.to raise_error(ArgumentError, 'ID is malformed') }
+      end
     end
 
     describe '.all' do


### PR DESCRIPTION
The intent of this PR is to not make someone who passes nil as a value have to chase down a method missing on NilClass error but rather to be specific about what was provided.

@dkubb ready for review. 