### PR TITLE
Add access to internet when VCR is turned off

### DIFF
--- a/spec/vcr_setup.rb
+++ b/spec/vcr_setup.rb
@@ -31,7 +31,9 @@ module BlockScore
 
   def run_vcr_example(options, example)
     if options.fetch(:record).equal?(:skip)
+      WebMock.allow_net_connect!
       VCR.turned_off(&example)
+      WebMock.disable_net_connect!
     else
       path = BlockScore.build_path(example.metadata.fetch(:full_description))
 


### PR DESCRIPTION
If record -> :skip is used, then most tests failed because access to the backend server was disallowed by WebMock. This temporarily allows external access and then turns it off again after example runs.

This permits mutant to run against the live server, which is necessary to eliminate false alive mutations. This also allows one to periodically confirm the VCR tests suite, which in this case highlighted a test that is passing but should not be.