### PR TITLE
Fix rubocop error

### DIFF
--- a/lib/blockscore/actions/retrieve.rb
+++ b/lib/blockscore/actions/retrieve.rb
@@ -11,7 +11,6 @@ module BlockScore
     # => #<BlockScore::Person:0x007fe39c424410>
     module Retrieve
       module ClassMethods
-
         RESOURCE_ID_FORMAT = /\A[a-f0-9]+\z/.freeze
 
         def retrieve(id, options = {})


### PR DESCRIPTION
This branch fixes a small rubocop error that oddly-enough was not flagged in a feature branch, but was flagged after merging into master.