### PR TITLE
Remove long-standing pending specs tied to issue #46 AR style impl.

### DIFF
--- a/spec/unit/blockscore/candidate_spec.rb
+++ b/spec/unit/blockscore/candidate_spec.rb
@@ -16,22 +16,6 @@ module BlockScore
       its(:class) { should be BlockScore::Candidate }
     end
 
-    pending '.find' do
-      context 'valid candidate id' do
-        let(:candidate_id)  { create(:candidate).id }
-        subject(:candidate) { BlockScore::Candidate.find(candidate_id) }
-
-        it { is_expected.to be_persisted }
-        its(:name_first) { is_expected.not_to be be_empty }
-      end
-
-      context 'invalid candidate id' do
-        let(:candidate_id) { '6c89646eea50fcaa42ca1fe1667a470b' }
-
-        it { expect { BlockScore::Candidate.find(candidate_id) }.to raise_error BlockScore::RecordNotFound }
-      end
-    end
-
     describe '.retrieve' do
       let(:candidate_id)  { create(:candidate).id }
       subject(:candidate) { BlockScore::Candidate.retrieve(candidate_id) }
@@ -80,15 +64,6 @@ module BlockScore
         it { is_expected.to be_persisted }
         its(:name_first) { is_expected.to eq 'Jane' }
       end
-
-      pending 'after deleting a candidate' do
-        subject(:candidate) { create(:candidate) }
-        before do
-          candidate.delete
-        end
-
-        it { expect { candidate.save }.to raise_error }
-      end
     end
 
     describe '#refresh' do
@@ -106,16 +81,6 @@ module BlockScore
 
       its(:class) { should be String }
       it { is_expected.to match(/^#<BlockScore::Candidate:0x/) }
-    end
-
-    pending '#update' do
-      subject(:candidate) { create(:candidate, name_first: 'John') }
-      before do
-        candidate.update(name_first: 'Jane')
-      end
-
-      it { is_expected.to be_persisted }
-      its(:name_first) { is_expected.to eq 'Jane' }
     end
 
     describe '#delete' do

--- a/spec/unit/blockscore/company_spec.rb
+++ b/spec/unit/blockscore/company_spec.rb
@@ -23,23 +23,6 @@ module BlockScore
       end
     end
 
-    pending '.find' do
-      context 'valid company id' do
-        let(:company_id)  { create(:company).id }
-        subject(:company) { BlockScore::Company.find(company_id) }
-
-        it { is_expected.to be_persisted }
-        its(:entity_name) { is_expected.not_to be_empty }
-        its(:class) { should be BlockScore::Company }
-      end
-
-      context 'invalid company id' do
-        let(:company_id) { 'e61fa4a8cf1426cdf5befd36abfb7300' }
-
-        it { expect { BlockScore::Company.find(company_id) }.to raise_error BlockScore::RecordNotFound }
-      end
-    end
-
     describe '.retrieve' do
       let(:company_id)  { create(:company).id }
       subject(:company) { BlockScore::Company.retrieve(company_id) }

--- a/spec/unit/blockscore/person_spec.rb
+++ b/spec/unit/blockscore/person_spec.rb
@@ -23,22 +23,6 @@ module BlockScore
       end
     end
 
-    pending '.find' do
-      context 'valid person id' do
-        let(:person_id)  { create(:person).id }
-        subject(:person) { BlockScore::Person.find(person_id) }
-
-        it { is_expected.to be_persisted }
-        its(:name_first) { is_expected.not_to be_empty }
-      end
-
-      context 'invalid person id' do
-        let(:person_id) { '6c89646eea50fcaa42ca1fe1667a470b' }
-
-        it { expect { BlockScore::Person.find(person_id) }.to raise_error BlockScore::RecordNotFound }
-      end
-    end
-
     describe '.retrieve' do
       let(:person_id)  { create(:person).id }
       subject(:person) { BlockScore::Person.retrieve(person_id) }

--- a/spec/unit/blockscore/question_set_spec.rb
+++ b/spec/unit/blockscore/question_set_spec.rb
@@ -23,22 +23,6 @@ module BlockScore
       end
     end
 
-    pending '.find' do
-      context 'valid question set id' do
-        let(:question_set_id)  { create(:question_set).id }
-        subject(:question_set) { BlockScore::QuestionSet.find(question_set_id) }
-
-        it { is_expected.to be_persisted }
-        its(:questions) { is_expected.not_to be_empty }
-      end
-
-      context 'invalid question set id' do
-        let(:question_set_id) { 'f3a243ddc8075a6acd603b7758d05b3c' }
-
-        it { expect { BlockScore::QuestionSet.find(question_set_id) }.to raise_error BlockScore::RecordNotFound }
-      end
-    end
-
     describe '.retrieve' do
       let(:question_set_id)  { create(:question_set).id }
       subject(:question_set) { BlockScore::QuestionSet.retrieve(question_set_id) }


### PR DESCRIPTION
Remove (for now) the pending specs associated with implementing an ActiveRecord style set of class methods in issue #46. These will be re-installed and updated if and when that issue is implemented.