### PR TITLE
Optimize target line length

### DIFF
--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -19,14 +19,14 @@ Style/StringLiterals:
 Metrics/LineLength:
   Max: 100
   Exclude:
-    - 'lib/blockscore/connection.rb'                              # temporary
-    - 'lib/blockscore/util.rb'                                    # temporary
-    - 'spec/unit/blockscore/candidate_spec.rb'                    # temporary
-    - 'spec/unit/blockscore/collection_spec.rb'                   # temporary
-    - 'spec/unit/blockscore/company_spec.rb'                      # temporary
-    - 'spec/unit/blockscore/person_spec.rb'                       # temporary
-    - 'spec/unit/blockscore/question_set_spec.rb'                 # temporary
-    - 'spec/unit/blockscore/errors/invalid_request_error_spec.rb' # temporary
+    - 'lib/blockscore/connection.rb'              # temporary
+    - 'spec/unit/blockscore/candidate_spec.rb'    # temporary
+    - 'spec/unit/blockscore/candidate_spec.rb'    # temporary
+    - 'spec/unit/blockscore/collection_spec.rb'   # temporary
+    - 'spec/unit/blockscore/company_spec.rb'      # temporary
+    - 'spec/unit/blockscore/person_spec.rb'       # temporary
+    - 'spec/unit/blockscore/question_set_spec.rb' # temporary
+    - 'spec/unit/blockscore/question_set_spec.rb' # temporary
 Style/DotPosition:
   EnforcedStyle: leading
 Style/CommentAnnotation:

--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -17,13 +17,17 @@ Style/ExtraSpacing:
 Style/StringLiterals:
   EnforcedStyle: single_quotes
 Metrics/LineLength:
-  Max: 100
+  Max: 80
+# DO not update the exclusions for the sake of fixing the line lengths
   Exclude:
-    - 'spec/unit/blockscore/candidate_spec.rb'    # temporary
-    - 'spec/unit/blockscore/collection_spec.rb'   # temporary
-    - 'spec/unit/blockscore/company_spec.rb'      # temporary
-    - 'spec/unit/blockscore/person_spec.rb'       # temporary
-    - 'spec/unit/blockscore/question_set_spec.rb' # temporary
+    - 'lib/blockscore/question_set.rb'                            # temporary
+    - 'spec/unit/blockscore/candidate_spec.rb'                    # temporary
+    - 'spec/unit/blockscore/collection_spec.rb'                   # temporary
+    - 'spec/unit/blockscore/company_spec.rb'                      # temporary
+    - 'spec/unit/blockscore/person_spec.rb'                       # temporary
+    - 'spec/unit/blockscore/question_set_spec.rb'                 # temporary
+    - 'spec/unit/blockscore/errors/invalid_request_error_spec.rb' # temporary
+    - 'spec/unit/blockscore/errors/not_found_error_spec.rb'       # temporary
 Style/DotPosition:
   EnforcedStyle: leading
 Style/CommentAnnotation:

--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -20,11 +20,9 @@ Metrics/LineLength:
   Max: 100
   Exclude:
     - 'spec/unit/blockscore/candidate_spec.rb'    # temporary
-    - 'spec/unit/blockscore/candidate_spec.rb'    # temporary
     - 'spec/unit/blockscore/collection_spec.rb'   # temporary
     - 'spec/unit/blockscore/company_spec.rb'      # temporary
     - 'spec/unit/blockscore/person_spec.rb'       # temporary
-    - 'spec/unit/blockscore/question_set_spec.rb' # temporary
     - 'spec/unit/blockscore/question_set_spec.rb' # temporary
 Style/DotPosition:
   EnforcedStyle: leading

--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -19,7 +19,6 @@ Style/StringLiterals:
 Metrics/LineLength:
   Max: 100
   Exclude:
-    - 'lib/blockscore/connection.rb'              # temporary
     - 'spec/unit/blockscore/candidate_spec.rb'    # temporary
     - 'spec/unit/blockscore/candidate_spec.rb'    # temporary
     - 'spec/unit/blockscore/collection_spec.rb'   # temporary

--- a/lib/blockscore/base.rb
+++ b/lib/blockscore/base.rb
@@ -4,6 +4,8 @@ module BlockScore
   class Base
     extend Connection
 
+    ABSTRACT_WARNING = 'Base is an abstract class, not an API resource'.freeze
+
     def initialize(options = {}, &block)
       @loaded = !(block)
       @proc = block
@@ -63,7 +65,7 @@ module BlockScore
     end
 
     def self.endpoint
-      fail NotImplementedError, 'Base is an abstract class, not an API resource' if equal?(Base)
+      fail NotImplementedError, ABSTRACT_WARNING if equal?(Base)
 
       "#{api_url}#{Util.to_plural(resource)}"
     end

--- a/lib/blockscore/collection.rb
+++ b/lib/blockscore/collection.rb
@@ -48,7 +48,7 @@ module BlockScore
     #
     # @example usage
     #
-    #   >> person = person = BlockScore::Person.retrieve('55de4af7643735000300000f')
+    #   >> person = BlockScore::Person.retrieve('55de4af7643735000300000f')
     #   >> person.question_sets.new
     #   => #<BlockScore::QuestionSet:0x3fc67902f1b4 JSON:{
     #     "person_id": "55de4af7643735000300000f"
@@ -123,7 +123,8 @@ module BlockScore
     # Retrieve a collection member by its id
     #
     # @example usage
-    #   person.question_sets.retrieve('55ef5b4e3532630003000178') # => instance of QuestionSet
+    #   person.question_sets.retrieve('55ef5b4e3532630003000178')
+    #           => instance of QuestionSet
     #
     # @param id [String] resource id
     #

--- a/lib/blockscore/collection/member.rb
+++ b/lib/blockscore/collection/member.rb
@@ -93,7 +93,16 @@ module BlockScore
       #
       # @api private
       def ids
-        parent.attributes.fetch(:"#{Util.to_plural(instance.class.resource)}", [])
+        parent.attributes.fetch(resource_name, [])
+      end
+
+      # Plural resource name as symbol
+      #
+      # @return Symbol
+      #
+      # @api private
+      def resource_name
+        Util.to_plural(instance.class.resource).to_sym
       end
     end
   end

--- a/lib/blockscore/connection.rb
+++ b/lib/blockscore/connection.rb
@@ -1,10 +1,11 @@
 module BlockScore
   module Connection
-    ACCEPT_HEADER =
-      "application/vnd.blockscore+json;version=#{BlockScore::VERSION.to_i}"
-    USER_AGENT =
-      "blockscore-ruby/#{BlockScore::VERSION} (https://github.com/BlockScore/blockscore-ruby)"
-    CONTENT_TYPE = 'application/json'
+    MAJOR_VERSION = BlockScore::VERSION.to_i
+    REPO          = 'https://github.com/BlockScore/blockscore-ruby'.freeze
+    API_VERSION   = "version=#{MAJOR_VERSION}".freeze
+    ACCEPT_HEADER = "application/vnd.blockscore+json;#{API_VERSION}".freeze
+    USER_AGENT    = "blockscore-ruby/#{BlockScore::VERSION} (#{REPO})".freeze
+    CONTENT_TYPE  = 'application/json'.freeze
 
     def get(path, params)
       request :get, path, params
@@ -26,8 +27,8 @@ module BlockScore
 
     def headers
       @headers ||= {
-        'Accept' => ACCEPT_HEADER,
-        'User-Agent' => USER_AGENT,
+        'Accept'       => ACCEPT_HEADER,
+        'User-Agent'   => USER_AGENT,
         'Content-Type' => CONTENT_TYPE
       }
     end

--- a/lib/blockscore/connection.rb
+++ b/lib/blockscore/connection.rb
@@ -1,5 +1,11 @@
 module BlockScore
   module Connection
+    ACCEPT_HEADER =
+      "application/vnd.blockscore+json;version=#{BlockScore::VERSION.to_i}"
+    USER_AGENT =
+      "blockscore-ruby/#{BlockScore::VERSION} (https://github.com/BlockScore/blockscore-ruby)"
+    CONTENT_TYPE = 'application/json'
+
     def get(path, params)
       request :get, path, params
     end
@@ -20,9 +26,9 @@ module BlockScore
 
     def headers
       @headers ||= {
-        'Accept' => "application/vnd.blockscore+json;version=#{BlockScore::VERSION.to_i}",
-        'User-Agent' => "blockscore-ruby/#{BlockScore::VERSION} (https://github.com/BlockScore/blockscore-ruby)",
-        'Content-Type' => 'application/json'
+        'Accept' => ACCEPT_HEADER,
+        'User-Agent' => USER_AGENT,
+        'Content-Type' => CONTENT_TYPE
       }
     end
 

--- a/lib/blockscore/util.rb
+++ b/lib/blockscore/util.rb
@@ -10,6 +10,10 @@ module BlockScore
       'watchlist_hit' => 'watchlist_hits'
     }
 
+    PARSE_ERROR =
+      'An error has occurred. ' \
+        'If this problem persists, please message support@blockscore.com.'
+
     def parse_json!(json_obj)
       JSON.parse(json_obj, symbolize_names: true)
     end
@@ -17,7 +21,7 @@ module BlockScore
     def parse_json(json_obj)
       parse_json! json_obj
     rescue JSON::ParserError
-      raise Error, 'An error has occurred. If this problem persists, please message support@blockscore.com.'
+      raise Error, PARSE_ERROR
     end
 
     def create_object(resource, options = {})
@@ -36,7 +40,8 @@ module BlockScore
     def to_constant(camel_cased_word)
       names = camel_cased_word.split('::')
 
-      # Trigger a built-in NameError exception including the ill-formed constant in the message.
+      # Trigger a built-in NameError exception including
+      # the ill-formed constant in the message.
       Object.const_get(camel_cased_word) if names.empty?
 
       # Remove the first blank element in case of '::ClassName' notation.

--- a/lib/blockscore/util.rb
+++ b/lib/blockscore/util.rb
@@ -3,16 +3,17 @@ module BlockScore
     extend self
 
     PLURAL_LOOKUP = {
-      'candidate' => 'candidates',
-      'company' => 'companies',
-      'person' => 'people',
-      'question_set' => 'question_sets',
+      'candidate'     => 'candidates',
+      'company'       => 'companies',
+      'person'        => 'people',
+      'question_set'  => 'question_sets',
       'watchlist_hit' => 'watchlist_hits'
     }
 
     PARSE_ERROR =
       'An error has occurred. ' \
-        'If this problem persists, please message support@blockscore.com.'
+        'If this problem persists, ' \
+        'please message support@blockscore.com.'.freeze
 
     def parse_json!(json_obj)
       JSON.parse(json_obj, symbolize_names: true)

--- a/spec/factories/companies.rb
+++ b/spec/factories/companies.rb
@@ -6,7 +6,9 @@ FactoryGirl.define do
     entity_name                 { Faker::Company.name }
     tax_id                      { '000000000' }
     incorporation_country_code  { Faker::Address.country_code }
-    incorporation_type          { %w(corporation llc partnership sp other).sample }
+    incorporation_type do
+      %w(corporation llc partnership sp other).sample
+    end
     address_street1             { Faker::Address.street_address }
     address_city                { Faker::Address.city }
     address_subdivision         { Faker::Address.state_abbr }

--- a/spec/support/question_set_helper.rb
+++ b/spec/support/question_set_helper.rb
@@ -1,5 +1,11 @@
 module QuestionSetHelper
-  VALID_ANSWERS = ['309 Colver Rd', '812', 'Jasper', '49230', 'None Of The Above']
+  VALID_ANSWERS = [
+    '309 Colver Rd'.freeze,
+    '812'.freeze,
+    'Jasper'.freeze,
+    '49230'.freeze,
+    'None Of The Above'.freeze
+  ].freeze
 
   def self.correct_answers(questions)
     answers(questions, true)

--- a/spec/unit/blockscore/util_spec.rb
+++ b/spec/unit/blockscore/util_spec.rb
@@ -103,7 +103,7 @@ module BlockScore
         let(:input) { '{{' }
         subject(:parse_attempt) { -> { described_class.parse_json(input) } }
 
-        it do
+        it 'raises an error when the json fails to parse' do
           expect { subject.call }.to raise_error do |err|
             expect(err).to be_an_instance_of(Error)
             expect(err.message).to eql(error)

--- a/spec/unit/blockscore/util_spec.rb
+++ b/spec/unit/blockscore/util_spec.rb
@@ -97,7 +97,8 @@ module BlockScore
 
       context 'translates errors' do
         let(:error) do
-          'An error has occurred. If this problem persists, please message support@blockscore.com.'
+          'An error has occurred. ' \
+          'If this problem persists, please message support@blockscore.com.'
         end
         let(:input) { '{{' }
         subject(:parse_attempt) { -> { described_class.parse_json(input) } }

--- a/spec/unit/blockscore/util_spec.rb
+++ b/spec/unit/blockscore/util_spec.rb
@@ -103,7 +103,12 @@ module BlockScore
         let(:input) { '{{' }
         subject(:parse_attempt) { -> { described_class.parse_json(input) } }
 
-        it { should raise_error(Error) { |err| expect(err.message).to eql(error) } }
+        it do
+          expect { subject.call }.to raise_error do |err|
+            expect(err).to be_an_instance_of(Error)
+            expect(err.message).to eql(error)
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
Using rubocop this PR lowers the line length max target to 80 for new code. 

I took the approach of quickly looking at the violations and determining if they could be easily corrected - especially in code vs. specs, or if by correcting this would add to the maintainability or correctness. This was done as an option to just adding the exclusion to rubocop. 