### PR TITLE
Upgrade the consistency of the scoring interface

### DIFF
--- a/lib/blockscore/question_set.rb
+++ b/lib/blockscore/question_set.rb
@@ -9,12 +9,14 @@ module BlockScore
     def_delegators 'self.class', :post, :endpoint
 
     def score(answers = nil)
-      if answers.nil? && attributes
-        attributes[:score]
-      else
-        @attributes = post("#{endpoint}/#{id}/score", answers: answers).attributes
-        score
-      end
+      rescore(answers) if answers
+      attributes.fetch(:score)
+    end
+
+    private
+
+    def rescore(answers)
+      @attributes = post("#{endpoint}/#{id}/score", answers: answers).attributes
     end
   end
 end

--- a/spec/cassettes/block_score/question_set/score/correct_answers.yml
+++ b/spec/cassettes/block_score/question_set/score/correct_answers.yml
@@ -255,4 +255,56 @@ http_interactions:
         Of The Above"}]}]}'
     http_version: 
   recorded_at: Fri, 18 Sep 2015 20:14:25 GMT
-recorded_with: VCR 2.9.3
+- request:
+    method: post
+    uri: https://BLOCKSCORE_TEST_KEY:@api.blockscore.com/question_sets/55fc70a0323833000300089c
+    body:
+      encoding: UTF-8
+      string: '{"answers":[{"question_id":1,"answer_id":4},{"question_id":2,"answer_id":1},{"question_id":3,"answer_id":5},{"question_id":4,"answer_id":2},{"question_id":5,"answer_id":5}]}'
+    headers:
+      Accept:
+      - application/vnd.blockscore+json;version=4
+      User-Agent:
+      - blockscore-ruby/4.2.1 (https://github.com/BlockScore/blockscore-ruby)
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Server:
+      - Cowboy
+      Connection:
+      - keep-alive
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Content-Type:
+      - application/json; charset=utf-8
+      Cache-Control:
+      - no-cache
+      X-Request-Id:
+      - d58bb5ab-0637-4ec8-b32a-27d660dcb234
+      X-Runtime:
+      - '0.007741'
+      Strict-Transport-Security:
+      - max-age=31536000
+      Date:
+      - Mon, 08 Feb 2016 22:54:55 GMT
+      X-Rack-Cache:
+      - invalidate, pass
+      Transfer-Encoding:
+      - chunked
+      Via:
+      - 1.1 vegur
+    body:
+      encoding: UTF-8
+      string: '{"error":{"type":"invalid_request_error","message":"Cannot create requests
+        at this path (POST /question_sets/55fc70a0323833000300089c)"}}'
+    http_version:
+  recorded_at: Mon, 08 Feb 2016 22:54:55 GMT
+recorded_with: VCR 3.0.1

--- a/spec/cassettes/block_score/question_set/score/incorrect_answers.yml
+++ b/spec/cassettes/block_score/question_set/score/incorrect_answers.yml
@@ -255,4 +255,58 @@ http_interactions:
         Hampshire"},{"id":4,"answer":"Utah"},{"id":5,"answer":"None Of The Above"}]}]}'
     http_version: 
   recorded_at: Fri, 18 Sep 2015 20:14:20 GMT
-recorded_with: VCR 2.9.3
+- request:
+    method: post
+    uri: https://BLOCKSCORE_TEST_KEY:@api.blockscore.com/question_sets/55fc709a39613800030008dc
+    body:
+      encoding: UTF-8
+      string: '{"answers":[{"question_id":1,"answer_id":2},{"question_id":2,"answer_id":2},{"question_id":3,"answer_id":2},{"question_id":4,"answer_id":0},{"question_id":5,"answer_id":1}]}'
+    headers:
+      Accept:
+      - application/vnd.blockscore+json;version=4
+      User-Agent:
+      - blockscore-ruby/4.2.1 (https://github.com/BlockScore/blockscore-ruby)
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Server:
+      - Cowboy
+      Connection:
+      - keep-alive
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Content-Type:
+      - application/json; charset=utf-8
+      Cache-Control:
+      - no-cache
+      X-Request-Id:
+      - 24eae17d-d08b-4dd4-910d-c4e5731306b0
+      X-Runtime:
+      - '0.007744'
+      Strict-Transport-Security:
+      - max-age=31536000
+      Date:
+      - Tue, 09 Feb 2016 02:21:55 GMT
+      X-Rack-Cache:
+      - invalidate, pass
+      Set-Cookie:
+      - __profilin=p%3Dt; path=/
+      Transfer-Encoding:
+      - chunked
+      Via:
+      - 1.1 vegur
+    body:
+      encoding: UTF-8
+      string: '{"error":{"type":"invalid_request_error","message":"Cannot create requests
+        at this path (POST /question_sets/55fc709a39613800030008dc)"}}'
+    http_version:
+  recorded_at: Tue, 09 Feb 2016 02:21:55 GMT
+recorded_with: VCR 3.0.1

--- a/spec/cassettes/block_score/question_set/score/malformed_answers.yml
+++ b/spec/cassettes/block_score/question_set/score/malformed_answers.yml
@@ -1,0 +1,177 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://BLOCKSCORE_TEST_KEY:@api.blockscore.com/people
+    body:
+      encoding: UTF-8
+      string: '{"name_first":"Tomas","name_last":"Collins","document_type":"ssn","document_value":"0000","birth_day":12,"birth_month":4,"birth_year":1945,"address_street1":"563
+        Catalina Green","address_city":"New Reannaborough","address_subdivision":"CA","address_postal_code":"84502-0414","address_country_code":"US"}'
+    headers:
+      Accept:
+      - application/vnd.blockscore+json;version=4
+      User-Agent:
+      - blockscore-ruby/4.2.1 (https://github.com/BlockScore/blockscore-ruby)
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Server:
+      - Cowboy
+      Connection:
+      - keep-alive
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"e33e478bf443fed585ec78b21913aabf"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 3c9c14be-ed27-4cde-a08b-32f2eff230d6
+      X-Runtime:
+      - '1.099440'
+      Strict-Transport-Security:
+      - max-age=31536000
+      Date:
+      - Mon, 08 Feb 2016 22:48:22 GMT
+      X-Rack-Cache:
+      - invalidate, pass
+      Set-Cookie:
+      - __profilin=p%3Dt; path=/
+      Transfer-Encoding:
+      - chunked
+      Via:
+      - 1.1 vegur
+    body:
+      encoding: UTF-8
+      string: '{"object":"person","id":"56b91b35623130000300023a","created_at":1454971701,"updated_at":1454971701,"status":"valid","livemode":false,"phone_number":null,"ip_address":null,"birth_day":12,"birth_month":4,"birth_year":1945,"name_first":"Tomas","name_middle":null,"name_last":"Collins","address_street1":"563
+        Catalina Green","address_street2":null,"address_city":"New Reannaborough","address_subdivision":"CA","address_postal_code":"84502-0414","address_country_code":"US","document_type":"ssn","document_value":"0000","note":null,"details":{"address":"no_match","address_risk":"low","identification":"no_match","date_of_birth":"not_found","ofac":"no_match","pep":"no_match"},"question_sets":[]}'
+    http_version:
+  recorded_at: Mon, 08 Feb 2016 22:48:22 GMT
+- request:
+    method: post
+    uri: https://BLOCKSCORE_TEST_KEY:@api.blockscore.com/question_sets
+    body:
+      encoding: UTF-8
+      string: '{"person_id":"56b91b35623130000300023a"}'
+    headers:
+      Accept:
+      - application/vnd.blockscore+json;version=4
+      User-Agent:
+      - blockscore-ruby/4.2.1 (https://github.com/BlockScore/blockscore-ruby)
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Server:
+      - Cowboy
+      Connection:
+      - keep-alive
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"af9cd2cf4d2a80de52be34e5af8ef02b"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 0373ec70-34e6-439e-a66d-c6463df3a08c
+      X-Runtime:
+      - '0.155128'
+      Strict-Transport-Security:
+      - max-age=31536000
+      Date:
+      - Mon, 08 Feb 2016 22:48:23 GMT
+      X-Rack-Cache:
+      - invalidate, pass
+      Transfer-Encoding:
+      - chunked
+      Via:
+      - 1.1 vegur
+    body:
+      encoding: UTF-8
+      string: '{"object":"question_set","id":"56b91b37636133000300019c","created_at":1454971703,"updated_at":1454971703,"livemode":false,"person_id":"56b91b35623130000300023a","score":null,"expired":false,"time_limit":0,"questions":[{"id":1,"question":"Which
+        one of the following addresses is associated with you?","answers":[{"id":1,"answer":"123
+        Main St"},{"id":2,"answer":"863 Carelton"},{"id":3,"answer":"52 Canandaigua
+        Rd"},{"id":4,"answer":"309 Colver Rd"},{"id":5,"answer":"None Of The Above"}]},{"id":2,"question":"Which
+        one of the following zip codes is associated with you?","answers":[{"id":1,"answer":"49230"},{"id":2,"answer":"49557"},{"id":3,"answer":"49993"},{"id":4,"answer":"49532"},{"id":5,"answer":"None
+        Of The Above"}]},{"id":3,"question":"Which one of the following area codes
+        is associated with you?","answers":[{"id":1,"answer":"870"},{"id":2,"answer":"904"},{"id":3,"answer":"336"},{"id":4,"answer":"812"},{"id":5,"answer":"None
+        Of The Above"}]},{"id":4,"question":"What state was your SSN issued in?","answers":[{"id":1,"answer":"California"},{"id":2,"answer":"Delaware"},{"id":3,"answer":"New
+        Hampshire"},{"id":4,"answer":"Maine"},{"id":5,"answer":"None Of The Above"}]},{"id":5,"question":"Which
+        one of the following counties is associated with you?","answers":[{"id":1,"answer":"Sangamon"},{"id":2,"answer":"Jasper"},{"id":3,"answer":"Orleans"},{"id":4,"answer":"Niagara"},{"id":5,"answer":"None
+        Of The Above"}]}]}'
+    http_version:
+  recorded_at: Mon, 08 Feb 2016 22:48:23 GMT
+- request:
+    method: post
+    uri: https://BLOCKSCORE_TEST_KEY:@api.blockscore.com/question_sets/56b91b37636133000300019c/score
+    body:
+      encoding: UTF-8
+      string: '{"answers":[]}'
+    headers:
+      Accept:
+      - application/vnd.blockscore+json;version=4
+      User-Agent:
+      - blockscore-ruby/4.2.1 (https://github.com/BlockScore/blockscore-ruby)
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 400
+      message: Bad Request
+    headers:
+      Server:
+      - Cowboy
+      Connection:
+      - keep-alive
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Content-Type:
+      - application/json; charset=utf-8
+      Cache-Control:
+      - no-cache
+      X-Request-Id:
+      - ef400c72-fa9d-4f32-a36d-b3074f3eb6c9
+      X-Runtime:
+      - '0.008795'
+      Strict-Transport-Security:
+      - max-age=31536000
+      Date:
+      - Mon, 08 Feb 2016 22:54:54 GMT
+      X-Rack-Cache:
+      - invalidate, pass
+      Set-Cookie:
+      - __profilin=p%3Dt; path=/
+      Transfer-Encoding:
+      - chunked
+      Via:
+      - 1.1 vegur
+    body:
+      encoding: UTF-8
+      string: '{"error":{"type":"invalid_request_error","message":"Answers should
+        be an array of objects"}}'
+    http_version:
+  recorded_at: Mon, 08 Feb 2016 22:54:54 GMT
+recorded_with: VCR 3.0.1

--- a/spec/cassettes/block_score/question_set/score/malformed_answers_raises_an_error_when_answers_are_not_an_array_of_hashes.yml
+++ b/spec/cassettes/block_score/question_set/score/malformed_answers_raises_an_error_when_answers_are_not_an_array_of_hashes.yml
@@ -1,0 +1,176 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://BLOCKSCORE_TEST_KEY:@api.blockscore.com/people
+    body:
+      encoding: UTF-8
+      string: '{"name_first":"Dorris","name_last":"Trantow","document_type":"ssn","document_value":"0000","birth_day":12,"birth_month":3,"birth_year":1922,"address_street1":"5539
+        Meghan Keys","address_city":"Kesslerview","address_subdivision":"MS","address_postal_code":"66138-3904","address_country_code":"US"}'
+    headers:
+      Accept:
+      - application/vnd.blockscore+json;version=4
+      User-Agent:
+      - blockscore-ruby/4.2.1 (https://github.com/BlockScore/blockscore-ruby)
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Server:
+      - Cowboy
+      Connection:
+      - keep-alive
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"c6db47ef87a2a111861b5ce7c73c86c8"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 15fb5d5d-9aaa-45ca-b52d-3a30ba33a2b1
+      X-Runtime:
+      - '0.276420'
+      Strict-Transport-Security:
+      - max-age=31536000
+      Date:
+      - Tue, 09 Feb 2016 02:04:13 GMT
+      X-Rack-Cache:
+      - invalidate, pass
+      Transfer-Encoding:
+      - chunked
+      Via:
+      - 1.1 vegur
+    body:
+      encoding: UTF-8
+      string: '{"object":"person","id":"56b9491d64653300030000c8","created_at":1454983453,"updated_at":1454983453,"status":"valid","livemode":false,"phone_number":null,"ip_address":null,"birth_day":12,"birth_month":3,"birth_year":1922,"name_first":"Dorris","name_middle":null,"name_last":"Trantow","address_street1":"5539
+        Meghan Keys","address_street2":null,"address_city":"Kesslerview","address_subdivision":"MS","address_postal_code":"66138-3904","address_country_code":"US","document_type":"ssn","document_value":"0000","note":null,"details":{"address":"no_match","address_risk":"low","identification":"no_match","date_of_birth":"not_found","ofac":"no_match","pep":"no_match"},"question_sets":[]}'
+    http_version:
+  recorded_at: Tue, 09 Feb 2016 02:04:13 GMT
+- request:
+    method: post
+    uri: https://BLOCKSCORE_TEST_KEY:@api.blockscore.com/question_sets
+    body:
+      encoding: UTF-8
+      string: '{"person_id":"56b9491d64653300030000c8"}'
+    headers:
+      Accept:
+      - application/vnd.blockscore+json;version=4
+      User-Agent:
+      - blockscore-ruby/4.2.1 (https://github.com/BlockScore/blockscore-ruby)
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Server:
+      - Cowboy
+      Connection:
+      - keep-alive
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"eca981b924e94f93ed4a58d69b56e8eb"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - c4f77a28-23a6-4265-9dbe-4386de256f60
+      X-Runtime:
+      - '0.095797'
+      Strict-Transport-Security:
+      - max-age=31536000
+      Date:
+      - Tue, 09 Feb 2016 02:04:14 GMT
+      X-Rack-Cache:
+      - invalidate, pass
+      Transfer-Encoding:
+      - chunked
+      Via:
+      - 1.1 vegur
+    body:
+      encoding: UTF-8
+      string: '{"object":"question_set","id":"56b9491e35633200030000c9","created_at":1454983454,"updated_at":1454983454,"livemode":false,"person_id":"56b9491d64653300030000c8","score":null,"expired":false,"time_limit":0,"questions":[{"id":1,"question":"What
+        state was your SSN issued in?","answers":[{"id":1,"answer":"Oklahoma"},{"id":2,"answer":"Utah"},{"id":3,"answer":"Oregon"},{"id":4,"answer":"California"},{"id":5,"answer":"None
+        Of The Above"}]},{"id":2,"question":"Which one of the following adult individuals
+        is most closely associated with you?","answers":[{"id":1,"answer":"Jose"},{"id":2,"answer":"Nathan"},{"id":3,"answer":"Nicole"},{"id":4,"answer":"Evan"},{"id":5,"answer":"None
+        Of The Above"}]},{"id":3,"question":"Which one of the following addresses
+        is associated with you?","answers":[{"id":1,"answer":"52 Canandaigua Rd"},{"id":2,"answer":"863
+        Carelton"},{"id":3,"answer":"123 Main St"},{"id":4,"answer":"309 Colver Rd"},{"id":5,"answer":"None
+        Of The Above"}]},{"id":4,"question":"Which one of the following area codes
+        is associated with you?","answers":[{"id":1,"answer":"812"},{"id":2,"answer":"336"},{"id":3,"answer":"308"},{"id":4,"answer":"605"},{"id":5,"answer":"None
+        Of The Above"}]},{"id":5,"question":"Which one of the following zip codes
+        is associated with you?","answers":[{"id":1,"answer":"49993"},{"id":2,"answer":"49230"},{"id":3,"answer":"49532"},{"id":4,"answer":"49268"},{"id":5,"answer":"None
+        Of The Above"}]}]}'
+    http_version:
+  recorded_at: Tue, 09 Feb 2016 02:04:14 GMT
+- request:
+    method: post
+    uri: https://BLOCKSCORE_TEST_KEY:@api.blockscore.com/question_sets/56b9491e35633200030000c9/score
+    body:
+      encoding: UTF-8
+      string: '{"answers":[]}'
+    headers:
+      Accept:
+      - application/vnd.blockscore+json;version=4
+      User-Agent:
+      - blockscore-ruby/4.2.1 (https://github.com/BlockScore/blockscore-ruby)
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 400
+      message: Bad Request
+    headers:
+      Server:
+      - Cowboy
+      Connection:
+      - keep-alive
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Content-Type:
+      - application/json; charset=utf-8
+      Cache-Control:
+      - no-cache
+      X-Request-Id:
+      - 313760be-1c3d-4169-bd80-881c37563b91
+      X-Runtime:
+      - '0.247877'
+      Strict-Transport-Security:
+      - max-age=31536000
+      Date:
+      - Tue, 09 Feb 2016 02:04:15 GMT
+      X-Rack-Cache:
+      - invalidate, pass
+      Set-Cookie:
+      - __profilin=p%3Dt; path=/
+      Transfer-Encoding:
+      - chunked
+      Via:
+      - 1.1 vegur
+    body:
+      encoding: UTF-8
+      string: '{"error":{"type":"invalid_request_error","message":"Answers should
+        be an array of objects"}}'
+    http_version:
+  recorded_at: Tue, 09 Feb 2016 02:04:15 GMT
+recorded_with: VCR 3.0.1

--- a/spec/cassettes/block_score/question_set/score/previous_answers.yml
+++ b/spec/cassettes/block_score/question_set/score/previous_answers.yml
@@ -1,0 +1,251 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://BLOCKSCORE_TEST_KEY:@api.blockscore.com/people
+    body:
+      encoding: UTF-8
+      string: '{"name_first":"Manuel","name_last":"Langosh","document_type":"ssn","document_value":"0000","birth_day":12,"birth_month":1,"birth_year":1999,"address_street1":"356
+        Doyle Junctions","address_city":"East Earlene","address_subdivision":"NJ","address_postal_code":"43767-2658","address_country_code":"US"}'
+    headers:
+      Accept:
+      - application/vnd.blockscore+json;version=4
+      User-Agent:
+      - blockscore-ruby/4.2.1 (https://github.com/BlockScore/blockscore-ruby)
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Server:
+      - Cowboy
+      Connection:
+      - keep-alive
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"18cc76ca8491f3b98808183f8989c363"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 389f9b5a-93d1-4d4f-be84-23fcc0a94e5c
+      X-Runtime:
+      - '0.939760'
+      Strict-Transport-Security:
+      - max-age=31536000
+      Date:
+      - Tue, 09 Feb 2016 02:13:08 GMT
+      X-Rack-Cache:
+      - invalidate, pass
+      Transfer-Encoding:
+      - chunked
+      Via:
+      - 1.1 vegur
+    body:
+      encoding: UTF-8
+      string: '{"object":"person","id":"56b94b3364653300030000db","created_at":1454983987,"updated_at":1454983987,"status":"valid","livemode":false,"phone_number":null,"ip_address":null,"birth_day":12,"birth_month":1,"birth_year":1999,"name_first":"Manuel","name_middle":null,"name_last":"Langosh","address_street1":"356
+        Doyle Junctions","address_street2":null,"address_city":"East Earlene","address_subdivision":"NJ","address_postal_code":"43767-2658","address_country_code":"US","document_type":"ssn","document_value":"0000","note":null,"details":{"address":"no_match","address_risk":"low","identification":"no_match","date_of_birth":"not_found","ofac":"no_match","pep":"no_match"},"question_sets":[]}'
+    http_version:
+  recorded_at: Tue, 09 Feb 2016 02:13:08 GMT
+- request:
+    method: post
+    uri: https://BLOCKSCORE_TEST_KEY:@api.blockscore.com/question_sets
+    body:
+      encoding: UTF-8
+      string: '{"person_id":"56b94b3364653300030000db"}'
+    headers:
+      Accept:
+      - application/vnd.blockscore+json;version=4
+      User-Agent:
+      - blockscore-ruby/4.2.1 (https://github.com/BlockScore/blockscore-ruby)
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Server:
+      - Cowboy
+      Connection:
+      - keep-alive
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"f9045a99992a58ed6ffcb85c47927bb4"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 171133eb-91d5-478c-aae7-cded68a2bb23
+      X-Runtime:
+      - '0.095067'
+      Strict-Transport-Security:
+      - max-age=31536000
+      Date:
+      - Tue, 09 Feb 2016 02:13:08 GMT
+      X-Rack-Cache:
+      - invalidate, pass
+      Transfer-Encoding:
+      - chunked
+      Via:
+      - 1.1 vegur
+    body:
+      encoding: UTF-8
+      string: '{"object":"question_set","id":"56b94b3435633200030000dc","created_at":1454983988,"updated_at":1454983988,"livemode":false,"person_id":"56b94b3364653300030000db","score":null,"expired":false,"time_limit":0,"questions":[{"id":1,"question":"Which
+        one of the following adult individuals is most closely associated with you?","answers":[{"id":1,"answer":"Luis"},{"id":2,"answer":"Miranda"},{"id":3,"answer":"Cecilia"},{"id":4,"answer":"Jason"},{"id":5,"answer":"None
+        Of The Above"}]},{"id":2,"question":"What state was your SSN issued in?","answers":[{"id":1,"answer":"Kentucky"},{"id":2,"answer":"Oregon"},{"id":3,"answer":"New
+        Hampshire"},{"id":4,"answer":"Idaho"},{"id":5,"answer":"None Of The Above"}]},{"id":3,"question":"Which
+        one of the following addresses is associated with you?","answers":[{"id":1,"answer":"902
+        Grass Lake Rd"},{"id":2,"answer":"123 Main St"},{"id":3,"answer":"309 Colver
+        Rd"},{"id":4,"answer":"863 Carelton"},{"id":5,"answer":"None Of The Above"}]},{"id":4,"question":"Which
+        one of the following zip codes is associated with you?","answers":[{"id":1,"answer":"49511"},{"id":2,"answer":"49230"},{"id":3,"answer":"49728"},{"id":4,"answer":"49209"},{"id":5,"answer":"None
+        Of The Above"}]},{"id":5,"question":"Which one of the following counties is
+        associated with you?","answers":[{"id":1,"answer":"Schoharie"},{"id":2,"answer":"Niagara"},{"id":3,"answer":"Floyd"},{"id":4,"answer":"Jasper"},{"id":5,"answer":"None
+        Of The Above"}]}]}'
+    http_version:
+  recorded_at: Tue, 09 Feb 2016 02:13:08 GMT
+- request:
+    method: post
+    uri: https://BLOCKSCORE_TEST_KEY:@api.blockscore.com/question_sets/56b94b3435633200030000dc/score
+    body:
+      encoding: UTF-8
+      string: '{"answers":[{"question_id":1,"answer_id":5},{"question_id":2,"answer_id":5},{"question_id":3,"answer_id":3},{"question_id":4,"answer_id":2},{"question_id":5,"answer_id":4}]}'
+    headers:
+      Accept:
+      - application/vnd.blockscore+json;version=4
+      User-Agent:
+      - blockscore-ruby/4.2.1 (https://github.com/BlockScore/blockscore-ruby)
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Server:
+      - Cowboy
+      Connection:
+      - keep-alive
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"171a72209a262bb7a445d1dd59dc4233"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - b49703aa-226e-4d10-90a9-cb66f605b558
+      X-Runtime:
+      - '0.043447'
+      Strict-Transport-Security:
+      - max-age=31536000
+      Date:
+      - Tue, 09 Feb 2016 02:21:54 GMT
+      X-Rack-Cache:
+      - invalidate, pass
+      Set-Cookie:
+      - __profilin=p%3Dt; path=/
+      Transfer-Encoding:
+      - chunked
+      Via:
+      - 1.1 vegur
+    body:
+      encoding: UTF-8
+      string: '{"object":"question_set","id":"56b94b3435633200030000dc","created_at":1454983988,"updated_at":1454984514,"livemode":false,"person_id":"56b94b3364653300030000db","score":100.0,"expired":false,"time_limit":0,"questions":[{"id":1,"question":"Which
+        one of the following adult individuals is most closely associated with you?","answers":[{"id":1,"answer":"Luis"},{"id":2,"answer":"Miranda"},{"id":3,"answer":"Cecilia"},{"id":4,"answer":"Jason"},{"id":5,"answer":"None
+        Of The Above"}]},{"id":2,"question":"What state was your SSN issued in?","answers":[{"id":1,"answer":"Kentucky"},{"id":2,"answer":"Oregon"},{"id":3,"answer":"New
+        Hampshire"},{"id":4,"answer":"Idaho"},{"id":5,"answer":"None Of The Above"}]},{"id":3,"question":"Which
+        one of the following addresses is associated with you?","answers":[{"id":1,"answer":"902
+        Grass Lake Rd"},{"id":2,"answer":"123 Main St"},{"id":3,"answer":"309 Colver
+        Rd"},{"id":4,"answer":"863 Carelton"},{"id":5,"answer":"None Of The Above"}]},{"id":4,"question":"Which
+        one of the following zip codes is associated with you?","answers":[{"id":1,"answer":"49511"},{"id":2,"answer":"49230"},{"id":3,"answer":"49728"},{"id":4,"answer":"49209"},{"id":5,"answer":"None
+        Of The Above"}]},{"id":5,"question":"Which one of the following counties is
+        associated with you?","answers":[{"id":1,"answer":"Schoharie"},{"id":2,"answer":"Niagara"},{"id":3,"answer":"Floyd"},{"id":4,"answer":"Jasper"},{"id":5,"answer":"None
+        Of The Above"}]}]}'
+    http_version:
+  recorded_at: Tue, 09 Feb 2016 02:21:54 GMT
+- request:
+    method: post
+    uri: https://BLOCKSCORE_TEST_KEY:@api.blockscore.com/question_sets/56b94b3435633200030000dc/score
+    body:
+      encoding: UTF-8
+      string: '{"answers":[{"question_id":1,"answer_id":1},{"question_id":2,"answer_id":1},{"question_id":3,"answer_id":4},{"question_id":4,"answer_id":3},{"question_id":5,"answer_id":0}]}'
+    headers:
+      Accept:
+      - application/vnd.blockscore+json;version=4
+      User-Agent:
+      - blockscore-ruby/4.2.1 (https://github.com/BlockScore/blockscore-ruby)
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Server:
+      - Cowboy
+      Connection:
+      - keep-alive
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"3fab45352d24dca4a271814b61cdec5e"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 7503934b-1add-4b2c-b637-30688462ebe0
+      X-Runtime:
+      - '0.046342'
+      Strict-Transport-Security:
+      - max-age=31536000
+      Date:
+      - Tue, 09 Feb 2016 02:21:54 GMT
+      X-Rack-Cache:
+      - invalidate, pass
+      Set-Cookie:
+      - __profilin=p%3Dt; path=/
+      Transfer-Encoding:
+      - chunked
+      Via:
+      - 1.1 vegur
+    body:
+      encoding: UTF-8
+      string: '{"object":"question_set","id":"56b94b3435633200030000dc","created_at":1454983988,"updated_at":1454984514,"livemode":false,"person_id":"56b94b3364653300030000db","score":0.0,"expired":false,"time_limit":0,"questions":[{"id":1,"question":"Which
+        one of the following adult individuals is most closely associated with you?","answers":[{"id":1,"answer":"Luis"},{"id":2,"answer":"Miranda"},{"id":3,"answer":"Cecilia"},{"id":4,"answer":"Jason"},{"id":5,"answer":"None
+        Of The Above"}]},{"id":2,"question":"What state was your SSN issued in?","answers":[{"id":1,"answer":"Kentucky"},{"id":2,"answer":"Oregon"},{"id":3,"answer":"New
+        Hampshire"},{"id":4,"answer":"Idaho"},{"id":5,"answer":"None Of The Above"}]},{"id":3,"question":"Which
+        one of the following addresses is associated with you?","answers":[{"id":1,"answer":"902
+        Grass Lake Rd"},{"id":2,"answer":"123 Main St"},{"id":3,"answer":"309 Colver
+        Rd"},{"id":4,"answer":"863 Carelton"},{"id":5,"answer":"None Of The Above"}]},{"id":4,"question":"Which
+        one of the following zip codes is associated with you?","answers":[{"id":1,"answer":"49511"},{"id":2,"answer":"49230"},{"id":3,"answer":"49728"},{"id":4,"answer":"49209"},{"id":5,"answer":"None
+        Of The Above"}]},{"id":5,"question":"Which one of the following counties is
+        associated with you?","answers":[{"id":1,"answer":"Schoharie"},{"id":2,"answer":"Niagara"},{"id":3,"answer":"Floyd"},{"id":4,"answer":"Jasper"},{"id":5,"answer":"None
+        Of The Above"}]}]}'
+    http_version:
+  recorded_at: Tue, 09 Feb 2016 02:21:54 GMT
+recorded_with: VCR 3.0.1

--- a/spec/cassettes/block_score/question_set/score/previous_answers_score.yml
+++ b/spec/cassettes/block_score/question_set/score/previous_answers_score.yml
@@ -1,0 +1,244 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://BLOCKSCORE_TEST_KEY:@api.blockscore.com/people
+    body:
+      encoding: UTF-8
+      string: '{"name_first":"Dasia","name_last":"Weber","document_type":"ssn","document_value":"0000","birth_day":12,"birth_month":12,"birth_year":1968,"address_street1":"396
+        Roslyn Centers","address_city":"Dakotachester","address_subdivision":"OH","address_postal_code":"91884-6556","address_country_code":"US"}'
+    headers:
+      Accept:
+      - application/vnd.blockscore+json;version=4
+      User-Agent:
+      - blockscore-ruby/4.2.1 (https://github.com/BlockScore/blockscore-ruby)
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Server:
+      - Cowboy
+      Connection:
+      - keep-alive
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"4e4d68a17b92285011765149b469d7f1"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 980a86e7-218d-4ccc-9c8a-e709bc40eb32
+      X-Runtime:
+      - '0.302392'
+      Strict-Transport-Security:
+      - max-age=31536000
+      Date:
+      - Tue, 09 Feb 2016 02:21:59 GMT
+      X-Rack-Cache:
+      - invalidate, pass
+      Set-Cookie:
+      - __profilin=p%3Dt; path=/
+      Transfer-Encoding:
+      - chunked
+      Via:
+      - 1.1 vegur
+    body:
+      encoding: UTF-8
+      string: '{"object":"person","id":"56b94d4764653300030000e3","created_at":1454984519,"updated_at":1454984519,"status":"valid","livemode":false,"phone_number":null,"ip_address":null,"birth_day":12,"birth_month":12,"birth_year":1968,"name_first":"Dasia","name_middle":null,"name_last":"Weber","address_street1":"396
+        Roslyn Centers","address_street2":null,"address_city":"Dakotachester","address_subdivision":"OH","address_postal_code":"91884-6556","address_country_code":"US","document_type":"ssn","document_value":"0000","note":null,"details":{"address":"no_match","address_risk":"low","identification":"no_match","date_of_birth":"not_found","ofac":"no_match","pep":"no_match"},"question_sets":[]}'
+    http_version:
+  recorded_at: Tue, 09 Feb 2016 02:21:59 GMT
+- request:
+    method: post
+    uri: https://BLOCKSCORE_TEST_KEY:@api.blockscore.com/question_sets
+    body:
+      encoding: UTF-8
+      string: '{"person_id":"56b94d4764653300030000e3"}'
+    headers:
+      Accept:
+      - application/vnd.blockscore+json;version=4
+      User-Agent:
+      - blockscore-ruby/4.2.1 (https://github.com/BlockScore/blockscore-ruby)
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Server:
+      - Cowboy
+      Connection:
+      - keep-alive
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"e7a996304ca84772b33aeab3f4ef4f52"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 7b5691d4-1e6c-4863-9e37-d7a00d80b567
+      X-Runtime:
+      - '0.093073'
+      Strict-Transport-Security:
+      - max-age=31536000
+      Date:
+      - Tue, 09 Feb 2016 02:22:00 GMT
+      X-Rack-Cache:
+      - invalidate, pass
+      Set-Cookie:
+      - __profilin=p%3Dt; path=/
+      Transfer-Encoding:
+      - chunked
+      Via:
+      - 1.1 vegur
+    body:
+      encoding: UTF-8
+      string: '{"object":"question_set","id":"56b94d4735633200030000ea","created_at":1454984519,"updated_at":1454984519,"livemode":false,"person_id":"56b94d4764653300030000e3","score":null,"expired":false,"time_limit":0,"questions":[{"id":1,"question":"Which
+        one of the following zip codes is associated with you?","answers":[{"id":1,"answer":"49230"},{"id":2,"answer":"49532"},{"id":3,"answer":"49557"},{"id":4,"answer":"49209"},{"id":5,"answer":"None
+        Of The Above"}]},{"id":2,"question":"Which one of the following area codes
+        is associated with you?","answers":[{"id":1,"answer":"870"},{"id":2,"answer":"336"},{"id":3,"answer":"812"},{"id":4,"answer":"228"},{"id":5,"answer":"None
+        Of The Above"}]},{"id":3,"question":"Which one of the following counties is
+        associated with you?","answers":[{"id":1,"answer":"Niagara"},{"id":2,"answer":"Jasper"},{"id":3,"answer":"Boone"},{"id":4,"answer":"Floyd"},{"id":5,"answer":"None
+        Of The Above"}]},{"id":4,"question":"Which one of the following adult individuals
+        is most closely associated with you?","answers":[{"id":1,"answer":"Cecilia"},{"id":2,"answer":"Jason"},{"id":3,"answer":"Nicole"},{"id":4,"answer":"Luis"},{"id":5,"answer":"None
+        Of The Above"}]},{"id":5,"question":"Which one of the following addresses
+        is associated with you?","answers":[{"id":1,"answer":"430 Dwight"},{"id":2,"answer":"902
+        Grass Lake Rd"},{"id":3,"answer":"221 Wolf Lake"},{"id":4,"answer":"309 Colver
+        Rd"},{"id":5,"answer":"None Of The Above"}]}]}'
+    http_version:
+  recorded_at: Tue, 09 Feb 2016 02:22:00 GMT
+- request:
+    method: post
+    uri: https://BLOCKSCORE_TEST_KEY:@api.blockscore.com/question_sets/56b94d4735633200030000ea/score
+    body:
+      encoding: UTF-8
+      string: '{"answers":[{"question_id":1,"answer_id":1},{"question_id":2,"answer_id":3},{"question_id":3,"answer_id":2},{"question_id":4,"answer_id":5},{"question_id":5,"answer_id":4}]}'
+    headers:
+      Accept:
+      - application/vnd.blockscore+json;version=4
+      User-Agent:
+      - blockscore-ruby/4.2.1 (https://github.com/BlockScore/blockscore-ruby)
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Server:
+      - Cowboy
+      Connection:
+      - keep-alive
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"c58856d5082c7f089fad1b5e27f55dd7"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - e982098e-9da8-4ef0-8132-d4ee71914996
+      X-Runtime:
+      - '0.042665'
+      Strict-Transport-Security:
+      - max-age=31536000
+      Date:
+      - Tue, 09 Feb 2016 02:22:00 GMT
+      X-Rack-Cache:
+      - invalidate, pass
+      Transfer-Encoding:
+      - chunked
+      Via:
+      - 1.1 vegur
+    body:
+      encoding: UTF-8
+      string: '{"object":"question_set","id":"56b94d4735633200030000ea","created_at":1454984519,"updated_at":1454984520,"livemode":false,"person_id":"56b94d4764653300030000e3","score":100.0,"expired":false,"time_limit":0,"questions":[{"id":1,"question":"Which
+        one of the following zip codes is associated with you?","answers":[{"id":1,"answer":"49230"},{"id":2,"answer":"49532"},{"id":3,"answer":"49557"},{"id":4,"answer":"49209"},{"id":5,"answer":"None
+        Of The Above"}]},{"id":2,"question":"Which one of the following area codes
+        is associated with you?","answers":[{"id":1,"answer":"870"},{"id":2,"answer":"336"},{"id":3,"answer":"812"},{"id":4,"answer":"228"},{"id":5,"answer":"None
+        Of The Above"}]},{"id":3,"question":"Which one of the following counties is
+        associated with you?","answers":[{"id":1,"answer":"Niagara"},{"id":2,"answer":"Jasper"},{"id":3,"answer":"Boone"},{"id":4,"answer":"Floyd"},{"id":5,"answer":"None
+        Of The Above"}]},{"id":4,"question":"Which one of the following adult individuals
+        is most closely associated with you?","answers":[{"id":1,"answer":"Cecilia"},{"id":2,"answer":"Jason"},{"id":3,"answer":"Nicole"},{"id":4,"answer":"Luis"},{"id":5,"answer":"None
+        Of The Above"}]},{"id":5,"question":"Which one of the following addresses
+        is associated with you?","answers":[{"id":1,"answer":"430 Dwight"},{"id":2,"answer":"902
+        Grass Lake Rd"},{"id":3,"answer":"221 Wolf Lake"},{"id":4,"answer":"309 Colver
+        Rd"},{"id":5,"answer":"None Of The Above"}]}]}'
+    http_version:
+  recorded_at: Tue, 09 Feb 2016 02:22:00 GMT
+- request:
+    method: post
+    uri: https://BLOCKSCORE_TEST_KEY:@api.blockscore.com/question_sets/56b94d4735633200030000ea/score
+    body:
+      encoding: UTF-8
+      string: '{"answers":null}'
+    headers:
+      Accept:
+      - application/vnd.blockscore+json;version=4
+      User-Agent:
+      - blockscore-ruby/4.2.1 (https://github.com/BlockScore/blockscore-ruby)
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 400
+      message: Bad Request
+    headers:
+      Server:
+      - Cowboy
+      Connection:
+      - keep-alive
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Content-Type:
+      - application/json; charset=utf-8
+      Cache-Control:
+      - no-cache
+      X-Request-Id:
+      - e5b04798-d522-4063-8a3a-e4d88dc284a3
+      X-Runtime:
+      - '0.153160'
+      Strict-Transport-Security:
+      - max-age=31536000
+      Date:
+      - Tue, 09 Feb 2016 02:22:01 GMT
+      X-Rack-Cache:
+      - invalidate, pass
+      Set-Cookie:
+      - __profilin=p%3Dt; path=/
+      Transfer-Encoding:
+      - chunked
+      Via:
+      - 1.1 vegur
+    body:
+      encoding: UTF-8
+      string: '{"error":{"type":"invalid_request_error","message":"Answers should
+        be an array of objects"}}'
+    http_version:
+  recorded_at: Tue, 09 Feb 2016 02:22:01 GMT
+recorded_with: VCR 3.0.1

--- a/spec/cassettes/block_score/question_set/score/previously_no_answers.yml
+++ b/spec/cassettes/block_score/question_set/score/previously_no_answers.yml
@@ -1,0 +1,126 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://BLOCKSCORE_TEST_KEY:@api.blockscore.com/people
+    body:
+      encoding: UTF-8
+      string: '{"name_first":"Edythe","name_last":"Sipes","document_type":"ssn","document_value":"0000","birth_day":12,"birth_month":3,"birth_year":1985,"address_street1":"695
+        Okuneva Garden","address_city":"Boganland","address_subdivision":"TN","address_postal_code":"91407-1759","address_country_code":"US"}'
+    headers:
+      Accept:
+      - application/vnd.blockscore+json;version=4
+      User-Agent:
+      - blockscore-ruby/4.2.1 (https://github.com/BlockScore/blockscore-ruby)
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Server:
+      - Cowboy
+      Connection:
+      - keep-alive
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"34e437d7a97ffd682e9f0b667cbf3555"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - ce49c5c6-dc4d-42fe-a124-e2a1c2a35e03
+      X-Runtime:
+      - '1.511196'
+      Strict-Transport-Security:
+      - max-age=31536000
+      Date:
+      - Mon, 08 Feb 2016 22:49:12 GMT
+      X-Rack-Cache:
+      - invalidate, pass
+      Set-Cookie:
+      - __profilin=p%3Dt; path=/
+      Transfer-Encoding:
+      - chunked
+      Via:
+      - 1.1 vegur
+    body:
+      encoding: UTF-8
+      string: '{"object":"person","id":"56b91b673565650003000ec0","created_at":1454971751,"updated_at":1454971751,"status":"valid","livemode":false,"phone_number":null,"ip_address":null,"birth_day":12,"birth_month":3,"birth_year":1985,"name_first":"Edythe","name_middle":null,"name_last":"Sipes","address_street1":"695
+        Okuneva Garden","address_street2":null,"address_city":"Boganland","address_subdivision":"TN","address_postal_code":"91407-1759","address_country_code":"US","document_type":"ssn","document_value":"0000","note":null,"details":{"address":"no_match","address_risk":"low","identification":"no_match","date_of_birth":"not_found","ofac":"no_match","pep":"no_match"},"question_sets":[]}'
+    http_version:
+  recorded_at: Mon, 08 Feb 2016 22:49:12 GMT
+- request:
+    method: post
+    uri: https://BLOCKSCORE_TEST_KEY:@api.blockscore.com/question_sets
+    body:
+      encoding: UTF-8
+      string: '{"person_id":"56b91b673565650003000ec0"}'
+    headers:
+      Accept:
+      - application/vnd.blockscore+json;version=4
+      User-Agent:
+      - blockscore-ruby/4.2.1 (https://github.com/BlockScore/blockscore-ruby)
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Server:
+      - Cowboy
+      Connection:
+      - keep-alive
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"c193950c51b73839a119621e2feb67e6"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 07edc047-6ca6-4b99-88c5-2bd89f812288
+      X-Runtime:
+      - '0.105033'
+      Strict-Transport-Security:
+      - max-age=31536000
+      Date:
+      - Mon, 08 Feb 2016 22:49:12 GMT
+      X-Rack-Cache:
+      - invalidate, pass
+      Set-Cookie:
+      - __profilin=p%3Dt; path=/
+      Transfer-Encoding:
+      - chunked
+      Via:
+      - 1.1 vegur
+    body:
+      encoding: UTF-8
+      string: '{"object":"question_set","id":"56b91b683565650003000ec2","created_at":1454971752,"updated_at":1454971752,"livemode":false,"person_id":"56b91b673565650003000ec0","score":null,"expired":false,"time_limit":0,"questions":[{"id":1,"question":"Which
+        one of the following counties is associated with you?","answers":[{"id":1,"answer":"Sangamon"},{"id":2,"answer":"Jasper"},{"id":3,"answer":"Floyd"},{"id":4,"answer":"Boone"},{"id":5,"answer":"None
+        Of The Above"}]},{"id":2,"question":"Which one of the following area codes
+        is associated with you?","answers":[{"id":1,"answer":"812"},{"id":2,"answer":"870"},{"id":3,"answer":"308"},{"id":4,"answer":"228"},{"id":5,"answer":"None
+        Of The Above"}]},{"id":3,"question":"What state was your SSN issued in?","answers":[{"id":1,"answer":"Maine"},{"id":2,"answer":"New
+        Hampshire"},{"id":3,"answer":"Idaho"},{"id":4,"answer":"Oregon"},{"id":5,"answer":"None
+        Of The Above"}]},{"id":4,"question":"Which one of the following zip codes
+        is associated with you?","answers":[{"id":1,"answer":"49993"},{"id":2,"answer":"49230"},{"id":3,"answer":"49511"},{"id":4,"answer":"49209"},{"id":5,"answer":"None
+        Of The Above"}]},{"id":5,"question":"Which one of the following addresses
+        is associated with you?","answers":[{"id":1,"answer":"52 Canandaigua Rd"},{"id":2,"answer":"902
+        Grass Lake Rd"},{"id":3,"answer":"221 Wolf Lake"},{"id":4,"answer":"309 Colver
+        Rd"},{"id":5,"answer":"None Of The Above"}]}]}'
+    http_version:
+  recorded_at: Mon, 08 Feb 2016 22:49:12 GMT
+recorded_with: VCR 3.0.1

--- a/spec/unit/blockscore/question_set_spec.rb
+++ b/spec/unit/blockscore/question_set_spec.rb
@@ -24,7 +24,7 @@ module BlockScore
     end
 
     describe '.retrieve' do
-      let(:question_set_id)  { create(:question_set).id }
+      let(:question_set_id) { create(:question_set).id }
       subject(:question_set) { BlockScore::QuestionSet.retrieve(question_set_id) }
 
       it { is_expected.to be_persisted }
@@ -38,17 +38,30 @@ module BlockScore
       let(:incorrect_answers) { QuestionSetHelper.incorrect_answers(question_set.questions) }
 
       context 'correct answers' do
-        before { question_set.score(correct_answers) }
-
-        its(:score) { should eq 100.0 }
-        it { expect(question_set.score(correct_answers)).to eq 100.0 }
+        it { expect(question_set.score(correct_answers)).to be 100.0 }
       end
 
       context 'incorrect answers' do
-        before { question_set.score(incorrect_answers) }
+        it { expect(question_set.score(incorrect_answers)).to be 0.0 }
+      end
 
-        its(:score) { should eq 0.0 }
-        it { expect(question_set.score(incorrect_answers)).to eq 0.0 }
+      context 'malformed answers' do
+        it 'raises an error when answers are not an array of hashes' do
+          expect { question_set.score([]) }
+            .to raise_error InvalidRequestError, \
+                            '(Type: invalid_request_error) ' \
+                            'Answers should be an array of objects  (Status: 400)'
+        end
+      end
+
+      context 'previous answers' do
+        before { question_set.score(correct_answers) }
+
+        it { expect(question_set.score).to be 100.0 }
+      end
+
+      context 'previously no answers' do
+        it { expect(question_set.score).to be nil }
       end
     end
 


### PR DESCRIPTION
This PR enforces the logic associated with the API Docs through specs which meet the following:

- If answers are provided to be scored they will be with a roundtrip to the server
- If malformed answers are provided they will also be passed to the server which should respond with InvalidRequestError
- If an empty set of answers are provided (proper format) then the score will be scored by server and return float 0.0
- If no answers are provided then the current score value is returned (nil if never scored, last score if previously scored question set)

Previously only correct answers and incorrect answers (both valid format) were tested completely.