### PR TITLE
Refactor RSpec arrangement and adjust namespaces

### DIFF
--- a/spec/cassettes/block_score/base/inspect.yml
+++ b/spec/cassettes/block_score/base/inspect.yml
@@ -1,0 +1,146 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://BLOCKSCORE_TEST_KEY:@api.blockscore.com/candidates
+    body:
+      encoding: UTF-8
+      string: '{"ssn":"0000","date_of_birth":"1958-04-02","name_first":"Jackson","name_last":"Feeney","address_street1":"2613
+        Xzavier Well","address_city":"South Ulises","address_country_code":"BI"}'
+    headers:
+      Accept:
+      - application/vnd.blockscore+json;version=4
+      User-Agent:
+      - blockscore-ruby/4.2.1 (https://github.com/BlockScore/blockscore-ruby)
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Server:
+      - Cowboy
+      Connection:
+      - keep-alive
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"b86b843583b0a5798d1cff3b05f7d5fc"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - a20a0574-d9c3-4a49-94b4-cfd81456049e
+      X-Runtime:
+      - '0.032482'
+      Strict-Transport-Security:
+      - max-age=31536000
+      Date:
+      - Thu, 11 Feb 2016 22:57:03 GMT
+      X-Rack-Cache:
+      - invalidate, pass
+      Transfer-Encoding:
+      - chunked
+      Via:
+      - 1.1 vegur
+    body:
+      encoding: UTF-8
+      string: '{"object":"candidate","id":"56bd11bf3366330003000386","created_at":1455231423,"updated_at":1455231423,"livemode":false,"note":null,"ssn":"0000","passport":null,"date_of_birth":"1958-04-02","name_first":"Jackson","name_middle":null,"name_last":"Feeney","address_street1":"2613
+        Xzavier Well","address_street2":null,"address_city":"South Ulises","address_subdivision":null,"address_postal_code":null,"address_country_code":"BI"}'
+    http_version:
+  recorded_at: Thu, 11 Feb 2016 22:57:03 GMT
+- request:
+    method: post
+    uri: https://BLOCKSCORE_TEST_KEY:@api.blockscore.com/
+    body:
+      encoding: UTF-8
+      string: '{"ssn":"0000","date_of_birth":"1996-01-17","name_first":"Hans","name_last":"Miller","address_street1":"231
+        Herman Street","address_city":"Tonyville","address_country_code":"CA"}'
+    headers:
+      Accept:
+      - application/vnd.blockscore+json;version=4
+      User-Agent:
+      - blockscore-ruby/4.2.1 (https://github.com/BlockScore/blockscore-ruby)
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Server:
+      - Cowboy
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Request-Id:
+      - ff622647-e8f0-4c6c-a258-d9abd497bce4
+      X-Runtime:
+      - '0.001922'
+      Strict-Transport-Security:
+      - max-age=31536000
+      Date:
+      - Thu, 11 Feb 2016 22:59:05 GMT
+      X-Rack-Cache:
+      - invalidate, pass
+      Content-Length:
+      - '36'
+      Via:
+      - 1.1 vegur
+    body:
+      encoding: UTF-8
+      string: '{"status":"404","error":"Not Found"}'
+    http_version:
+  recorded_at: Thu, 11 Feb 2016 22:59:05 GMT
+- request:
+    method: patch
+    uri: https://BLOCKSCORE_TEST_KEY:@api.blockscore.com/candidates/
+    body:
+      encoding: UTF-8
+      string: '{"ssn":"0000","date_of_birth":"1953-09-03","name_first":"Deangelo","name_last":"Hane","address_street1":"504
+        Mayer Radial","address_city":"Port Dameon","address_country_code":"HM"}'
+    headers:
+      Accept:
+      - application/vnd.blockscore+json;version=4
+      User-Agent:
+      - blockscore-ruby/4.2.1 (https://github.com/BlockScore/blockscore-ruby)
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Server:
+      - Cowboy
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Request-Id:
+      - 37147a6f-3333-4c47-9496-017b643637f9
+      X-Runtime:
+      - '0.002268'
+      Strict-Transport-Security:
+      - max-age=31536000
+      Date:
+      - Thu, 11 Feb 2016 22:59:35 GMT
+      X-Rack-Cache:
+      - invalidate, pass
+      Content-Length:
+      - '36'
+      Via:
+      - 1.1 vegur
+    body:
+      encoding: UTF-8
+      string: '{"status":"404","error":"Not Found"}'
+    http_version:
+  recorded_at: Thu, 11 Feb 2016 22:59:35 GMT
+recorded_with: VCR 3.0.1

--- a/spec/cassettes/block_score/base/refresh/name_last.yml
+++ b/spec/cassettes/block_score/base/refresh/name_last.yml
@@ -1,0 +1,209 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://BLOCKSCORE_TEST_KEY:@api.blockscore.com/candidates
+    body:
+      encoding: UTF-8
+      string: '{"ssn":"0000","date_of_birth":"1935-12-05","name_first":"Electa","name_last":"Smith","address_street1":"4318
+        Hermann Mount","address_city":"Kreigerberg","address_country_code":"NO"}'
+    headers:
+      Accept:
+      - application/vnd.blockscore+json;version=4
+      User-Agent:
+      - blockscore-ruby/4.2.1 (https://github.com/BlockScore/blockscore-ruby)
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Server:
+      - Cowboy
+      Connection:
+      - keep-alive
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"b37ba820099bb215377e8e145f81262e"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - fa3aec77-c93f-43f7-addd-38e8108e405f
+      X-Runtime:
+      - '0.046432'
+      Strict-Transport-Security:
+      - max-age=31536000
+      Date:
+      - Thu, 11 Feb 2016 22:57:00 GMT
+      X-Rack-Cache:
+      - invalidate, pass
+      Transfer-Encoding:
+      - chunked
+      Via:
+      - 1.1 vegur
+    body:
+      encoding: UTF-8
+      string: '{"object":"candidate","id":"56bd11bc336633000300037a","created_at":1455231420,"updated_at":1455231420,"livemode":false,"note":null,"ssn":"0000","passport":null,"date_of_birth":"1935-12-05","name_first":"Electa","name_middle":null,"name_last":"Smith","address_street1":"4318
+        Hermann Mount","address_street2":null,"address_city":"Kreigerberg","address_subdivision":null,"address_postal_code":null,"address_country_code":"NO"}'
+    http_version:
+  recorded_at: Thu, 11 Feb 2016 22:57:00 GMT
+- request:
+    method: get
+    uri: https://BLOCKSCORE_TEST_KEY:@api.blockscore.com/candidates/56bd11bc336633000300037a
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/vnd.blockscore+json;version=4
+      User-Agent:
+      - blockscore-ruby/4.2.1 (https://github.com/BlockScore/blockscore-ruby)
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Cowboy
+      Connection:
+      - keep-alive
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"b37ba820099bb215377e8e145f81262e"
+      Cache-Control:
+      - must-revalidate, private, max-age=0
+      X-Request-Id:
+      - 2017984f-0022-4639-8967-b9464b98e4b9
+      X-Runtime:
+      - '0.019710'
+      Strict-Transport-Security:
+      - max-age=31536000
+      Date:
+      - Thu, 11 Feb 2016 22:57:00 GMT
+      X-Rack-Cache:
+      - miss
+      Transfer-Encoding:
+      - chunked
+      Via:
+      - 1.1 vegur
+    body:
+      encoding: UTF-8
+      string: '{"object":"candidate","id":"56bd11bc336633000300037a","created_at":1455231420,"updated_at":1455231420,"livemode":false,"note":null,"ssn":"0000","passport":null,"date_of_birth":"1935-12-05","name_first":"Electa","name_middle":null,"name_last":"Smith","address_street1":"4318
+        Hermann Mount","address_street2":null,"address_city":"Kreigerberg","address_subdivision":null,"address_postal_code":null,"address_country_code":"NO"}'
+    http_version:
+  recorded_at: Thu, 11 Feb 2016 22:57:00 GMT
+- request:
+    method: post
+    uri: https://BLOCKSCORE_TEST_KEY:@api.blockscore.com/candidate
+    body:
+      encoding: UTF-8
+      string: '{"ssn":"0000","date_of_birth":"1998-07-28","name_first":"Victor","name_last":"Smith","address_street1":"472
+        Heathcote Manor","address_city":"Lake Curtisburgh","address_country_code":"SK"}'
+    headers:
+      Accept:
+      - application/vnd.blockscore+json;version=4
+      User-Agent:
+      - blockscore-ruby/4.2.1 (https://github.com/BlockScore/blockscore-ruby)
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Server:
+      - Cowboy
+      Connection:
+      - keep-alive
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Content-Type:
+      - application/json; charset=utf-8
+      Cache-Control:
+      - no-cache
+      X-Request-Id:
+      - 415a0f1e-6274-4cc9-8885-a38782027b8f
+      X-Runtime:
+      - '0.006769'
+      Strict-Transport-Security:
+      - max-age=31536000
+      Date:
+      - Thu, 11 Feb 2016 22:57:05 GMT
+      X-Rack-Cache:
+      - invalidate, pass
+      Transfer-Encoding:
+      - chunked
+      Via:
+      - 1.1 vegur
+    body:
+      encoding: UTF-8
+      string: '{"error":{"type":"invalid_request_error","message":"Cannot create requests
+        at this path (POST /candidate)"}}'
+    http_version:
+  recorded_at: Thu, 11 Feb 2016 22:57:05 GMT
+- request:
+    method: patch
+    uri: https://BLOCKSCORE_TEST_KEY:@api.blockscore.com/candidates/
+    body:
+      encoding: UTF-8
+      string: '{"ssn":"0000","date_of_birth":"1938-09-12","name_first":"Selmer","name_last":"Smith","address_street1":"501
+        Windler Burgs","address_city":"North Evalyn","address_country_code":"LR"}'
+    headers:
+      Accept:
+      - application/vnd.blockscore+json;version=4
+      User-Agent:
+      - blockscore-ruby/4.2.1 (https://github.com/BlockScore/blockscore-ruby)
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Server:
+      - Cowboy
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Request-Id:
+      - 18a6ddb9-7f37-4a4f-ab38-e27b0f8ba032
+      X-Runtime:
+      - '0.002899'
+      Strict-Transport-Security:
+      - max-age=31536000
+      Date:
+      - Thu, 11 Feb 2016 22:57:31 GMT
+      X-Rack-Cache:
+      - invalidate, pass
+      Content-Length:
+      - '36'
+      Via:
+      - 1.1 vegur
+    body:
+      encoding: UTF-8
+      string: '{"status":"404","error":"Not Found"}'
+    http_version:
+  recorded_at: Thu, 11 Feb 2016 22:57:31 GMT
+recorded_with: VCR 3.0.1

--- a/spec/cassettes/block_score/base/save/when_creating_a_new_candidate.yml
+++ b/spec/cassettes/block_score/base/save/when_creating_a_new_candidate.yml
@@ -1,0 +1,58 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://BLOCKSCORE_TEST_KEY:@api.blockscore.com/candidates
+    body:
+      encoding: UTF-8
+      string: '{"ssn":"0000","date_of_birth":"2015-11-25","name_first":"Adrianna","name_last":"Daniel","address_street1":"827
+        Parisian Fall","address_city":"South Freda","address_country_code":"CV"}'
+    headers:
+      Accept:
+      - application/vnd.blockscore+json;version=4
+      User-Agent:
+      - blockscore-ruby/4.2.1 (https://github.com/BlockScore/blockscore-ruby)
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Server:
+      - Cowboy
+      Connection:
+      - keep-alive
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"fa59fb7c4ebd0859b400147fa46a5e86"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 30878293-35dd-4f61-9bf0-bec8d4062af3
+      X-Runtime:
+      - '0.059384'
+      Strict-Transport-Security:
+      - max-age=31536000
+      Date:
+      - Thu, 11 Feb 2016 22:57:02 GMT
+      X-Rack-Cache:
+      - invalidate, pass
+      Transfer-Encoding:
+      - chunked
+      Via:
+      - 1.1 vegur
+    body:
+      encoding: UTF-8
+      string: '{"object":"candidate","id":"56bd11be646661000300037b","created_at":1455231422,"updated_at":1455231422,"livemode":false,"note":null,"ssn":"0000","passport":null,"date_of_birth":"2015-11-25","name_first":"Adrianna","name_middle":null,"name_last":"Daniel","address_street1":"827
+        Parisian Fall","address_street2":null,"address_city":"South Freda","address_subdivision":null,"address_postal_code":null,"address_country_code":"CV"}'
+    http_version:
+  recorded_at: Thu, 11 Feb 2016 22:57:03 GMT
+recorded_with: VCR 3.0.1

--- a/spec/cassettes/block_score/base/save/when_creating_a_new_candidate_name_first.yml
+++ b/spec/cassettes/block_score/base/save/when_creating_a_new_candidate_name_first.yml
@@ -1,0 +1,58 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://BLOCKSCORE_TEST_KEY:@api.blockscore.com/candidates
+    body:
+      encoding: UTF-8
+      string: '{"ssn":"0000","date_of_birth":"1962-08-11","name_first":"Anthony","name_last":"Stiedemann","address_street1":"1038
+        Will Drives","address_city":"Helenland","address_country_code":"IR"}'
+    headers:
+      Accept:
+      - application/vnd.blockscore+json;version=4
+      User-Agent:
+      - blockscore-ruby/4.2.1 (https://github.com/BlockScore/blockscore-ruby)
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Server:
+      - Cowboy
+      Connection:
+      - keep-alive
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"d7d5562fab3f0fa2eedadd50d6e2af40"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 2db7f031-e4a1-4a92-b877-db241d6580b2
+      X-Runtime:
+      - '0.035040'
+      Strict-Transport-Security:
+      - max-age=31536000
+      Date:
+      - Thu, 11 Feb 2016 22:57:03 GMT
+      X-Rack-Cache:
+      - invalidate, pass
+      Transfer-Encoding:
+      - chunked
+      Via:
+      - 1.1 vegur
+    body:
+      encoding: UTF-8
+      string: '{"object":"candidate","id":"56bd11bf353065000300036e","created_at":1455231423,"updated_at":1455231423,"livemode":false,"note":null,"ssn":"0000","passport":null,"date_of_birth":"1962-08-11","name_first":"Anthony","name_middle":null,"name_last":"Stiedemann","address_street1":"1038
+        Will Drives","address_street2":null,"address_city":"Helenland","address_subdivision":null,"address_postal_code":null,"address_country_code":"IR"}'
+    http_version:
+  recorded_at: Thu, 11 Feb 2016 22:57:03 GMT
+recorded_with: VCR 3.0.1

--- a/spec/cassettes/block_score/base/save/when_updating_an_existing_candidate.yml
+++ b/spec/cassettes/block_score/base/save/when_updating_an_existing_candidate.yml
@@ -1,0 +1,168 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://BLOCKSCORE_TEST_KEY:@api.blockscore.com/candidates
+    body:
+      encoding: UTF-8
+      string: '{"ssn":"0000","date_of_birth":"1995-05-16","name_first":"John","name_last":"Kris","address_street1":"42286
+        Considine Squares","address_city":"New Brigitte","address_country_code":"PS"}'
+    headers:
+      Accept:
+      - application/vnd.blockscore+json;version=4
+      User-Agent:
+      - blockscore-ruby/4.2.1 (https://github.com/BlockScore/blockscore-ruby)
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Server:
+      - Cowboy
+      Connection:
+      - keep-alive
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"bd85e8f0040b0fee5ee11967996b2924"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 59b32c9a-afda-407d-b58f-18a0d05756f6
+      X-Runtime:
+      - '0.039187'
+      Strict-Transport-Security:
+      - max-age=31536000
+      Date:
+      - Thu, 11 Feb 2016 22:57:00 GMT
+      X-Rack-Cache:
+      - invalidate, pass
+      Transfer-Encoding:
+      - chunked
+      Via:
+      - 1.1 vegur
+    body:
+      encoding: UTF-8
+      string: '{"object":"candidate","id":"56bd11bc6466610003000377","created_at":1455231420,"updated_at":1455231420,"livemode":false,"note":null,"ssn":"0000","passport":null,"date_of_birth":"1995-05-16","name_first":"John","name_middle":null,"name_last":"Kris","address_street1":"42286
+        Considine Squares","address_street2":null,"address_city":"New Brigitte","address_subdivision":null,"address_postal_code":null,"address_country_code":"PS"}'
+    http_version:
+  recorded_at: Thu, 11 Feb 2016 22:57:00 GMT
+- request:
+    method: patch
+    uri: https://BLOCKSCORE_TEST_KEY:@api.blockscore.com/candidates/56bd11bc6466610003000377
+    body:
+      encoding: UTF-8
+      string: '{"note":null,"ssn":"0000","passport":null,"date_of_birth":"1995-05-16","name_first":"Jane","name_middle":null,"name_last":"Kris","address_street1":"42286
+        Considine Squares","address_street2":null,"address_city":"New Brigitte","address_subdivision":null,"address_postal_code":null,"address_country_code":"PS"}'
+    headers:
+      Accept:
+      - application/vnd.blockscore+json;version=4
+      User-Agent:
+      - blockscore-ruby/4.2.1 (https://github.com/BlockScore/blockscore-ruby)
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Cowboy
+      Connection:
+      - keep-alive
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"eb5ebc653df4192c02de6d1417ca2edc"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 6aec7e98-da68-41bd-983a-1f1c91f378f6
+      X-Runtime:
+      - '0.022676'
+      Strict-Transport-Security:
+      - max-age=31536000
+      Date:
+      - Thu, 11 Feb 2016 22:57:01 GMT
+      X-Rack-Cache:
+      - invalidate, pass
+      Transfer-Encoding:
+      - chunked
+      Via:
+      - 1.1 vegur
+    body:
+      encoding: UTF-8
+      string: '{"object":"candidate","id":"56bd11bc6466610003000377","created_at":1455231420,"updated_at":1455231421,"livemode":false,"note":null,"ssn":"0000","passport":null,"date_of_birth":"1995-05-16","name_first":"Jane","name_middle":null,"name_last":"Kris","address_street1":"42286
+        Considine Squares","address_street2":null,"address_city":"New Brigitte","address_subdivision":null,"address_postal_code":null,"address_country_code":"PS"}'
+    http_version:
+  recorded_at: Thu, 11 Feb 2016 22:57:01 GMT
+- request:
+    method: post
+    uri: https://BLOCKSCORE_TEST_KEY:@api.blockscore.com/candidates
+    body:
+      encoding: UTF-8
+      string: '{"object":"candidate","id":"56bd11bc6466610003000377","created_at":1455231420,"updated_at":1455231420,"livemode":false,"note":null,"ssn":"0000","passport":null,"date_of_birth":"1995-05-16","name_first":"Jane","name_middle":null,"name_last":"Kris","address_street1":"42286
+        Considine Squares","address_street2":null,"address_city":"New Brigitte","address_subdivision":null,"address_postal_code":null,"address_country_code":"PS"}'
+    headers:
+      Accept:
+      - application/vnd.blockscore+json;version=4
+      User-Agent:
+      - blockscore-ruby/4.2.1 (https://github.com/BlockScore/blockscore-ruby)
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Server:
+      - Cowboy
+      Connection:
+      - keep-alive
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"f89d1981b22af8513325ecde9a5abd84"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 21360e16-b258-4486-8153-2f62ba3a89c9
+      X-Runtime:
+      - '0.035735'
+      Strict-Transport-Security:
+      - max-age=31536000
+      Date:
+      - Thu, 11 Feb 2016 22:57:30 GMT
+      X-Rack-Cache:
+      - invalidate, pass
+      Transfer-Encoding:
+      - chunked
+      Via:
+      - 1.1 vegur
+    body:
+      encoding: UTF-8
+      string: '{"object":"candidate","id":"56bd11da3530650003000386","created_at":1455231450,"updated_at":1455231450,"livemode":false,"note":null,"ssn":"0000","passport":null,"date_of_birth":"1995-05-16","name_first":"Jane","name_middle":null,"name_last":"Kris","address_street1":"42286
+        Considine Squares","address_street2":null,"address_city":"New Brigitte","address_subdivision":null,"address_postal_code":null,"address_country_code":"PS"}'
+    http_version:
+  recorded_at: Thu, 11 Feb 2016 22:57:30 GMT
+recorded_with: VCR 3.0.1

--- a/spec/cassettes/block_score/base/save/when_updating_an_existing_candidate_name_first.yml
+++ b/spec/cassettes/block_score/base/save/when_updating_an_existing_candidate_name_first.yml
@@ -1,0 +1,113 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://BLOCKSCORE_TEST_KEY:@api.blockscore.com/candidates
+    body:
+      encoding: UTF-8
+      string: '{"ssn":"0000","date_of_birth":"2003-02-10","name_first":"John","name_last":"Lind","address_street1":"125
+        Danny Corner","address_city":"Lake Hermannside","address_country_code":"AM"}'
+    headers:
+      Accept:
+      - application/vnd.blockscore+json;version=4
+      User-Agent:
+      - blockscore-ruby/4.2.1 (https://github.com/BlockScore/blockscore-ruby)
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Server:
+      - Cowboy
+      Connection:
+      - keep-alive
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"484c5562dd929fe5bfa5e23385e085c7"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 99cfdfa4-5491-4e38-bf76-44e3abf9c916
+      X-Runtime:
+      - '0.039436'
+      Strict-Transport-Security:
+      - max-age=31536000
+      Date:
+      - Thu, 11 Feb 2016 22:57:01 GMT
+      X-Rack-Cache:
+      - invalidate, pass
+      Transfer-Encoding:
+      - chunked
+      Via:
+      - 1.1 vegur
+    body:
+      encoding: UTF-8
+      string: '{"object":"candidate","id":"56bd11bd6466610003000379","created_at":1455231421,"updated_at":1455231421,"livemode":false,"note":null,"ssn":"0000","passport":null,"date_of_birth":"2003-02-10","name_first":"John","name_middle":null,"name_last":"Lind","address_street1":"125
+        Danny Corner","address_street2":null,"address_city":"Lake Hermannside","address_subdivision":null,"address_postal_code":null,"address_country_code":"AM"}'
+    http_version:
+  recorded_at: Thu, 11 Feb 2016 22:57:01 GMT
+- request:
+    method: patch
+    uri: https://BLOCKSCORE_TEST_KEY:@api.blockscore.com/candidates/56bd11bd6466610003000379
+    body:
+      encoding: UTF-8
+      string: '{"note":null,"ssn":"0000","passport":null,"date_of_birth":"2003-02-10","name_first":"Jane","name_middle":null,"name_last":"Lind","address_street1":"125
+        Danny Corner","address_street2":null,"address_city":"Lake Hermannside","address_subdivision":null,"address_postal_code":null,"address_country_code":"AM"}'
+    headers:
+      Accept:
+      - application/vnd.blockscore+json;version=4
+      User-Agent:
+      - blockscore-ruby/4.2.1 (https://github.com/BlockScore/blockscore-ruby)
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Cowboy
+      Connection:
+      - keep-alive
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"099f4933a6c7e0e25f209b1d1ff8355e"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 08508693-1d9a-4d54-b3fa-9d0b4c7eb4de
+      X-Runtime:
+      - '0.020061'
+      Strict-Transport-Security:
+      - max-age=31536000
+      Date:
+      - Thu, 11 Feb 2016 22:57:02 GMT
+      X-Rack-Cache:
+      - invalidate, pass
+      Transfer-Encoding:
+      - chunked
+      Via:
+      - 1.1 vegur
+    body:
+      encoding: UTF-8
+      string: '{"object":"candidate","id":"56bd11bd6466610003000379","created_at":1455231421,"updated_at":1455231422,"livemode":false,"note":null,"ssn":"0000","passport":null,"date_of_birth":"2003-02-10","name_first":"Jane","name_middle":null,"name_last":"Lind","address_street1":"125
+        Danny Corner","address_street2":null,"address_city":"Lake Hermannside","address_subdivision":null,"address_postal_code":null,"address_country_code":"AM"}'
+    http_version:
+  recorded_at: Thu, 11 Feb 2016 22:57:02 GMT
+recorded_with: VCR 3.0.1

--- a/spec/cassettes/block_score/candidate/history.yml
+++ b/spec/cassettes/block_score/candidate/history.yml
@@ -229,4 +229,166 @@ http_interactions:
         Swift Field","address_street2":null,"address_city":"Urielville","address_subdivision":null,"address_postal_code":null,"address_country_code":"YT"}]'
     http_version: 
   recorded_at: Fri, 18 Sep 2015 17:11:01 GMT
-recorded_with: VCR 2.9.3
+- request:
+    method: get
+    uri: https://BLOCKSCORE_TEST_KEY:@api.blockscore.com/candidates/55fc45a33961380003000738/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/vnd.blockscore+json;version=4
+      User-Agent:
+      - blockscore-ruby/4.2.1 (https://github.com/BlockScore/blockscore-ruby)
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Server:
+      - Cowboy
+      Connection:
+      - keep-alive
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Content-Type:
+      - application/json; charset=utf-8
+      Cache-Control:
+      - no-cache, private
+      X-Request-Id:
+      - 235e27ec-c59d-4523-9577-8e2476e07907
+      X-Runtime:
+      - '0.010751'
+      Strict-Transport-Security:
+      - max-age=31536000
+      Date:
+      - Thu, 11 Feb 2016 20:09:33 GMT
+      X-Rack-Cache:
+      - miss
+      Set-Cookie:
+      - __profilin=p%3Dt; path=/
+      Transfer-Encoding:
+      - chunked
+      Via:
+      - 1.1 vegur
+    body:
+      encoding: UTF-8
+      string: '{"error":{"type":"invalid_request_error","message":"Candidate with
+        id 55fc45a33961380003000738 could not be found"}}'
+    http_version:
+  recorded_at: Thu, 11 Feb 2016 20:09:33 GMT
+- request:
+    method: get
+    uri: https://BLOCKSCORE_TEST_KEY:@api.blockscore.com/candidates55fc45a33961380003000738/history
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/vnd.blockscore+json;version=4
+      User-Agent:
+      - blockscore-ruby/4.2.1 (https://github.com/BlockScore/blockscore-ruby)
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Server:
+      - Cowboy
+      Connection:
+      - keep-alive
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Content-Type:
+      - application/json; charset=utf-8
+      Cache-Control:
+      - no-cache, private
+      X-Request-Id:
+      - ca5838f6-8035-49a7-945a-2e2db1eb143a
+      X-Runtime:
+      - '0.006281'
+      Strict-Transport-Security:
+      - max-age=31536000
+      Date:
+      - Thu, 11 Feb 2016 20:11:10 GMT
+      X-Rack-Cache:
+      - miss
+      Set-Cookie:
+      - __profilin=p%3Dt; path=/
+      Transfer-Encoding:
+      - chunked
+      Via:
+      - 1.1 vegur
+    body:
+      encoding: UTF-8
+      string: '{"error":{"type":"invalid_request_error","message":"Cannot create requests
+        at this path (GET /candidates55fc45a33961380003000738/history)"}}'
+    http_version:
+  recorded_at: Thu, 11 Feb 2016 20:11:10 GMT
+- request:
+    method: get
+    uri: https://BLOCKSCORE_TEST_KEY:@api.blockscore.com/candidates/55fc45a33961380003000738history
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/vnd.blockscore+json;version=4
+      User-Agent:
+      - blockscore-ruby/4.2.1 (https://github.com/BlockScore/blockscore-ruby)
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Server:
+      - Cowboy
+      Connection:
+      - keep-alive
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Content-Type:
+      - application/json; charset=utf-8
+      Cache-Control:
+      - no-cache, private
+      X-Request-Id:
+      - deb38a1c-007e-4bc2-aca8-3417a052aa4f
+      X-Runtime:
+      - '0.008045'
+      Strict-Transport-Security:
+      - max-age=31536000
+      Date:
+      - Thu, 11 Feb 2016 20:11:10 GMT
+      X-Rack-Cache:
+      - miss
+      Set-Cookie:
+      - __profilin=p%3Dt; path=/
+      Transfer-Encoding:
+      - chunked
+      Via:
+      - 1.1 vegur
+    body:
+      encoding: UTF-8
+      string: '{"error":{"type":"invalid_request_error","message":"Candidate with
+        id 55fc45a33961380003000738history could not be found"}}'
+    http_version:
+  recorded_at: Thu, 11 Feb 2016 20:11:10 GMT
+recorded_with: VCR 3.0.1

--- a/spec/cassettes/block_score/candidate/hits/returns_a_watchlist_hit.yml
+++ b/spec/cassettes/block_score/candidate/hits/returns_a_watchlist_hit.yml
@@ -1,0 +1,466 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://BLOCKSCORE_TEST_KEY:@api.blockscore.com/candidates
+    body:
+      encoding: UTF-8
+      string: '{"ssn":null,"date_of_birth":null,"name_first":"John","name_last":"Bredenkamp","address_street1":null,"address_city":null,"address_country_code":null}'
+    headers:
+      Accept:
+      - application/vnd.blockscore+json;version=4
+      User-Agent:
+      - blockscore-ruby/4.2.1 (https://github.com/BlockScore/blockscore-ruby)
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Server:
+      - Cowboy
+      Connection:
+      - keep-alive
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"a6b2a06b6659378b0c2e5404d27657c7"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 25254af3-fa91-4f81-9056-4a20016526dd
+      X-Runtime:
+      - '0.040355'
+      Strict-Transport-Security:
+      - max-age=31536000
+      Date:
+      - Thu, 11 Feb 2016 20:11:06 GMT
+      X-Rack-Cache:
+      - invalidate, pass
+      Set-Cookie:
+      - __profilin=p%3Dt; path=/
+      Transfer-Encoding:
+      - chunked
+      Via:
+      - 1.1 vegur
+    body:
+      encoding: UTF-8
+      string: '{"object":"candidate","id":"56bceada3534370003000048","created_at":1455221466,"updated_at":1455221466,"livemode":false,"note":null,"ssn":null,"passport":null,"date_of_birth":null,"name_first":"John","name_middle":null,"name_last":"Bredenkamp","address_street1":null,"address_street2":null,"address_city":null,"address_subdivision":null,"address_postal_code":null,"address_country_code":null}'
+    http_version:
+  recorded_at: Thu, 11 Feb 2016 20:11:06 GMT
+- request:
+    method: post
+    uri: https://BLOCKSCORE_TEST_KEY:@api.blockscore.com/watchlists
+    body:
+      encoding: UTF-8
+      string: '{"candidate_id":"56bceada3534370003000048"}'
+    headers:
+      Accept:
+      - application/vnd.blockscore+json;version=4
+      User-Agent:
+      - blockscore-ruby/4.2.1 (https://github.com/BlockScore/blockscore-ruby)
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Cowboy
+      Connection:
+      - keep-alive
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"ea97ec10d87b1310a2bcefe4d694ddad"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - a6a38fd9-8ca0-4415-b5e1-b454d0602e0f
+      X-Runtime:
+      - '0.042150'
+      Strict-Transport-Security:
+      - max-age=31536000
+      Date:
+      - Thu, 11 Feb 2016 20:11:06 GMT
+      X-Rack-Cache:
+      - invalidate, pass
+      Set-Cookie:
+      - __profilin=p%3Dt; path=/
+      Transfer-Encoding:
+      - chunked
+      Via:
+      - 1.1 vegur
+    body:
+      encoding: UTF-8
+      string: '{"livemode":false,"searched_lists":[],"count":1,"matches":[{"id":"ent_554056e4b4cf7103000009d5","watchlist_name":"US_SDN","entry_type":"individual","matching_info":["name"],"confidence":1.0,"url":null,"notes":null,"title":null,"name_full":"John
+        Bredenkamp","alternate_names":"John A. Bredenkamp; John Arnold Bredenkamp","date_of_birth":"1940-8-11","passport":"367537C;
+        Z153612; Z01024064; ND1285143","ssn":null,"address_street1":"62 Chester Square","address_street2":null,"address_city":"London","address_state":null,"address_postal_code":null,"address_country_code":"GB","address_raw":"62
+        Chester Square, London, GB","names":[{"name_primary":true,"name_full":"John
+        Bredenkamp","name_strength":"medium"},{"name_primary":false,"name_full":"John
+        A. Bredenkamp","name_strength":"medium"},{"name_primary":false,"name_full":"John
+        Arnold Bredenkamp","name_strength":"medium"}],"births":[{"birth_day":11,"birth_month":8,"birth_year":1940,"birth_day_end":null,"birth_month_end":null,"birth_year_end":null}],"documents":[{"document_type":"passport","document_value":"367537C","document_country_code":"SR"},{"document_type":"passport","document_value":"Z153612","document_country_code":"NL"},{"document_type":"passport","document_value":"Z01024064","document_country_code":"NL"},{"document_type":"passport","document_value":"ND1285143","document_country_code":"NL"}],"addresses":[{"address_street1":"62
+        Chester Square","address_street2":null,"address_city":"London","address_state":null,"address_postal_code":null,"address_country_code":"GB","address_full":"62
+        Chester Square, London, GB"},{"address_street1":"Dennerlei 30","address_street2":null,"address_city":"Schoten","address_state":null,"address_postal_code":null,"address_country_code":"BE","address_full":"Dennerlei
+        30, Schoten, BE"},{"address_street1":"Mapstone House","address_street2":"Mapstone
+        Hill Lustleigh","address_city":"Newton Abbot","address_state":null,"address_postal_code":"TQ13
+        9SE","address_country_code":"GB","address_full":"Mapstone House, Mapstone
+        Hill Lustleigh, Newton Abbot, Devon, TQ13 9SE, GB"},{"address_street1":"New
+        Boundary House","address_street2":"London Road Sunningdale","address_city":"Ascot","address_state":null,"address_postal_code":"SL5
+        0DJ","address_country_code":"GB","address_full":"New Boundary House, London
+        Road Sunningdale, Ascot, Berkshire, SL5 0DJ, GB"},{"address_street1":"Middleton
+        House","address_street2":"Titlarks Hill Road Sunningdale","address_city":"Ascot","address_state":null,"address_postal_code":"SL5
+        0JB","address_country_code":"GB","address_full":"Middleton House, Titlarks
+        Hill Road Sunningdale, Ascot, Berkshire, SL5 0JB, GB"},{"address_street1":"Hurst
+        Grove","address_street2":"Sanford Lane Hurst","address_city":"Reading","address_state":null,"address_postal_code":"RG10
+        0SQ","address_country_code":"GB","address_full":"Hurst Grove, Sanford Lane
+        Hurst, Reading, Berkshire, RG10 0SQ, GB"},{"address_street1":"10 Montpelier
+        Square","address_street2":null,"address_city":"London","address_state":null,"address_postal_code":"SW7
+        1JU","address_country_code":"GB","address_full":"10 Montpelier Square, London,
+        SW7 1JU, GB"},{"address_street1":"Thetford Farm","address_street2":"P.O. Box
+        HP86 Mount Pleasant","address_city":"Harare","address_state":null,"address_postal_code":null,"address_country_code":"ZW","address_full":"Thetford
+        Farm, P.O. Box HP86 Mount Pleasant, Harare, ZW"}]}]}'
+    http_version:
+  recorded_at: Thu, 11 Feb 2016 20:11:06 GMT
+- request:
+    method: get
+    uri: https://BLOCKSCORE_TEST_KEY:@api.blockscore.com/candidates/56bceada3534370003000048/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/vnd.blockscore+json;version=4
+      User-Agent:
+      - blockscore-ruby/4.2.1 (https://github.com/BlockScore/blockscore-ruby)
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Cowboy
+      Connection:
+      - keep-alive
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"a6b2a06b6659378b0c2e5404d27657c7"
+      Cache-Control:
+      - must-revalidate, private, max-age=0
+      X-Request-Id:
+      - d9563f1e-b956-487f-97ea-e32dd0a684f3
+      X-Runtime:
+      - '0.008795'
+      Strict-Transport-Security:
+      - max-age=31536000
+      Date:
+      - Thu, 11 Feb 2016 20:11:07 GMT
+      X-Rack-Cache:
+      - miss
+      Set-Cookie:
+      - __profilin=p%3Dt; path=/
+      Transfer-Encoding:
+      - chunked
+      Via:
+      - 1.1 vegur
+    body:
+      encoding: UTF-8
+      string: '{"object":"candidate","id":"56bceada3534370003000048","created_at":1455221466,"updated_at":1455221466,"livemode":false,"note":null,"ssn":null,"passport":null,"date_of_birth":null,"name_first":"John","name_middle":null,"name_last":"Bredenkamp","address_street1":null,"address_street2":null,"address_city":null,"address_subdivision":null,"address_postal_code":null,"address_country_code":null}'
+    http_version:
+  recorded_at: Thu, 11 Feb 2016 20:11:07 GMT
+- request:
+    method: get
+    uri: https://BLOCKSCORE_TEST_KEY:@api.blockscore.com/candidates/56bceada3534370003000048/hits
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/vnd.blockscore+json;version=4
+      User-Agent:
+      - blockscore-ruby/4.2.1 (https://github.com/BlockScore/blockscore-ruby)
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Cowboy
+      Connection:
+      - keep-alive
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"305860599c62ce3d57b15d7374ae72da"
+      Cache-Control:
+      - must-revalidate, private, max-age=0
+      X-Request-Id:
+      - 0068e088-85a9-47ce-9971-386d3ecb9b4b
+      X-Runtime:
+      - '0.034209'
+      Strict-Transport-Security:
+      - max-age=31536000
+      Date:
+      - Thu, 11 Feb 2016 20:11:09 GMT
+      X-Rack-Cache:
+      - miss
+      Set-Cookie:
+      - __profilin=p%3Dt; path=/
+      Transfer-Encoding:
+      - chunked
+      Via:
+      - 1.1 vegur
+    body:
+      encoding: UTF-8
+      string: '{"object":"list","data":[]}'
+    http_version:
+  recorded_at: Thu, 11 Feb 2016 20:11:09 GMT
+- request:
+    method: get
+    uri: https://BLOCKSCORE_TEST_KEY:@api.blockscore.com/candidates/56bceada3534370003000048/hits
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/vnd.blockscore+json;version=4
+      User-Agent:
+      - blockscore-ruby/4.2.1 (https://github.com/BlockScore/blockscore-ruby)
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Cowboy
+      Connection:
+      - keep-alive
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"305860599c62ce3d57b15d7374ae72da"
+      Cache-Control:
+      - must-revalidate, private, max-age=0
+      X-Request-Id:
+      - 89e2534e-179c-4626-a25c-9f30a1539197
+      X-Runtime:
+      - '1.147895'
+      Strict-Transport-Security:
+      - max-age=31536000
+      Date:
+      - Thu, 11 Feb 2016 20:11:11 GMT
+      X-Rack-Cache:
+      - miss
+      Set-Cookie:
+      - __profilin=p%3Dt; path=/
+      Transfer-Encoding:
+      - chunked
+      Via:
+      - 1.1 vegur
+    body:
+      encoding: UTF-8
+      string: '{"object":"list","data":[]}'
+    http_version:
+  recorded_at: Thu, 11 Feb 2016 20:11:11 GMT
+- request:
+    method: get
+    uri: https://BLOCKSCORE_TEST_KEY:@api.blockscore.com/candidates/56bceada3534370003000048/hits
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/vnd.blockscore+json;version=4
+      User-Agent:
+      - blockscore-ruby/4.2.1 (https://github.com/BlockScore/blockscore-ruby)
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Cowboy
+      Connection:
+      - keep-alive
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"571c342d856ce661515ab8cb385cb3a0"
+      Cache-Control:
+      - must-revalidate, private, max-age=0
+      X-Request-Id:
+      - 522f54ba-05a1-4e24-b098-faf12d31b801
+      X-Runtime:
+      - '0.053148'
+      Strict-Transport-Security:
+      - max-age=31536000
+      Date:
+      - Thu, 11 Feb 2016 20:11:13 GMT
+      X-Rack-Cache:
+      - miss
+      Set-Cookie:
+      - __profilin=p%3Dt; path=/
+      Transfer-Encoding:
+      - chunked
+      Via:
+      - 1.1 vegur
+    body:
+      encoding: UTF-8
+      string: '{"object":"list","data":[{"id":"ent_554056e4b4cf7103000009d5","list":"US_SDN","entry_type":"individual","matching_info":["name"],"confidence":1.0,"livemode":false,"url":null,"notes":null,"title":null,"name_full":"John
+        Arnold Bredenkamp","alternate_names":"John A. Bredenkamp; John Bredenkamp","date_of_birth":"1940-8-11","id_type":"passport","id_value":"367537C","address_street1":"62
+        Chester Square","address_street2":null,"address_city":"London","address_state":null,"address_postal_code":null,"address_country_code":"GB","address_raw":"62
+        Chester Square, London, GB","names":[{"name_primary":false,"name_full":"John
+        Arnold Bredenkamp","name_strength":"medium"},{"name_primary":false,"name_full":"John
+        A. Bredenkamp","name_strength":"medium"},{"name_primary":true,"name_full":"John
+        Bredenkamp","name_strength":"medium"}],"births":[{"birth_day":11,"birth_month":8,"birth_year":1940,"birth_day_end":null,"birth_month_end":null,"birth_year_end":null}],"documents":[{"document_type":"passport","document_value":"367537C","document_country_code":"SR"},{"document_type":"passport","document_value":"Z153612","document_country_code":"NL"},{"document_type":"passport","document_value":"Z01024064","document_country_code":"NL"},{"document_type":"passport","document_value":"ND1285143","document_country_code":"NL"}],"addresses":[{"address_street1":"62
+        Chester Square","address_street2":null,"address_city":"London","address_state":null,"address_postal_code":null,"address_country_code":"GB","address_full":"62
+        Chester Square, London, GB"},{"address_street1":"Dennerlei 30","address_street2":null,"address_city":"Schoten","address_state":null,"address_postal_code":null,"address_country_code":"BE","address_full":"Dennerlei
+        30, Schoten, BE"},{"address_street1":"Mapstone House","address_street2":"Mapstone
+        Hill Lustleigh","address_city":"Newton Abbot","address_state":null,"address_postal_code":"TQ13
+        9SE","address_country_code":"GB","address_full":"Mapstone House, Mapstone
+        Hill Lustleigh, Newton Abbot, Devon, TQ13 9SE, GB"},{"address_street1":"New
+        Boundary House","address_street2":"London Road Sunningdale","address_city":"Ascot","address_state":null,"address_postal_code":"SL5
+        0DJ","address_country_code":"GB","address_full":"New Boundary House, London
+        Road Sunningdale, Ascot, Berkshire, SL5 0DJ, GB"},{"address_street1":"Middleton
+        House","address_street2":"Titlarks Hill Road Sunningdale","address_city":"Ascot","address_state":null,"address_postal_code":"SL5
+        0JB","address_country_code":"GB","address_full":"Middleton House, Titlarks
+        Hill Road Sunningdale, Ascot, Berkshire, SL5 0JB, GB"},{"address_street1":"Hurst
+        Grove","address_street2":"Sanford Lane Hurst","address_city":"Reading","address_state":null,"address_postal_code":"RG10
+        0SQ","address_country_code":"GB","address_full":"Hurst Grove, Sanford Lane
+        Hurst, Reading, Berkshire, RG10 0SQ, GB"},{"address_street1":"10 Montpelier
+        Square","address_street2":null,"address_city":"London","address_state":null,"address_postal_code":"SW7
+        1JU","address_country_code":"GB","address_full":"10 Montpelier Square, London,
+        SW7 1JU, GB"},{"address_street1":"Thetford Farm","address_street2":"P.O. Box
+        HP86 Mount Pleasant","address_city":"Harare","address_state":null,"address_postal_code":null,"address_country_code":"ZW","address_full":"Thetford
+        Farm, P.O. Box HP86 Mount Pleasant, Harare, ZW"}]}]}'
+    http_version:
+  recorded_at: Thu, 11 Feb 2016 20:11:13 GMT
+- request:
+    method: get
+    uri: https://BLOCKSCORE_TEST_KEY:@api.blockscore.com/candidates/56bceada3534370003000048/hits
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/vnd.blockscore+json;version=4
+      User-Agent:
+      - blockscore-ruby/4.2.1 (https://github.com/BlockScore/blockscore-ruby)
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Cowboy
+      Connection:
+      - keep-alive
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"571c342d856ce661515ab8cb385cb3a0"
+      Cache-Control:
+      - must-revalidate, private, max-age=0
+      X-Request-Id:
+      - 55d71b1d-3edf-4f7d-9c30-2e53532907cd
+      X-Runtime:
+      - '0.030479'
+      Strict-Transport-Security:
+      - max-age=31536000
+      Date:
+      - Thu, 11 Feb 2016 20:11:13 GMT
+      X-Rack-Cache:
+      - miss
+      Set-Cookie:
+      - __profilin=p%3Dt; path=/
+      Transfer-Encoding:
+      - chunked
+      Via:
+      - 1.1 vegur
+    body:
+      encoding: UTF-8
+      string: '{"object":"list","data":[{"id":"ent_554056e4b4cf7103000009d5","list":"US_SDN","entry_type":"individual","matching_info":["name"],"confidence":1.0,"livemode":false,"url":null,"notes":null,"title":null,"name_full":"John
+        Arnold Bredenkamp","alternate_names":"John A. Bredenkamp; John Bredenkamp","date_of_birth":"1940-8-11","id_type":"passport","id_value":"367537C","address_street1":"62
+        Chester Square","address_street2":null,"address_city":"London","address_state":null,"address_postal_code":null,"address_country_code":"GB","address_raw":"62
+        Chester Square, London, GB","names":[{"name_primary":false,"name_full":"John
+        Arnold Bredenkamp","name_strength":"medium"},{"name_primary":false,"name_full":"John
+        A. Bredenkamp","name_strength":"medium"},{"name_primary":true,"name_full":"John
+        Bredenkamp","name_strength":"medium"}],"births":[{"birth_day":11,"birth_month":8,"birth_year":1940,"birth_day_end":null,"birth_month_end":null,"birth_year_end":null}],"documents":[{"document_type":"passport","document_value":"367537C","document_country_code":"SR"},{"document_type":"passport","document_value":"Z153612","document_country_code":"NL"},{"document_type":"passport","document_value":"Z01024064","document_country_code":"NL"},{"document_type":"passport","document_value":"ND1285143","document_country_code":"NL"}],"addresses":[{"address_street1":"62
+        Chester Square","address_street2":null,"address_city":"London","address_state":null,"address_postal_code":null,"address_country_code":"GB","address_full":"62
+        Chester Square, London, GB"},{"address_street1":"Dennerlei 30","address_street2":null,"address_city":"Schoten","address_state":null,"address_postal_code":null,"address_country_code":"BE","address_full":"Dennerlei
+        30, Schoten, BE"},{"address_street1":"Mapstone House","address_street2":"Mapstone
+        Hill Lustleigh","address_city":"Newton Abbot","address_state":null,"address_postal_code":"TQ13
+        9SE","address_country_code":"GB","address_full":"Mapstone House, Mapstone
+        Hill Lustleigh, Newton Abbot, Devon, TQ13 9SE, GB"},{"address_street1":"New
+        Boundary House","address_street2":"London Road Sunningdale","address_city":"Ascot","address_state":null,"address_postal_code":"SL5
+        0DJ","address_country_code":"GB","address_full":"New Boundary House, London
+        Road Sunningdale, Ascot, Berkshire, SL5 0DJ, GB"},{"address_street1":"Middleton
+        House","address_street2":"Titlarks Hill Road Sunningdale","address_city":"Ascot","address_state":null,"address_postal_code":"SL5
+        0JB","address_country_code":"GB","address_full":"Middleton House, Titlarks
+        Hill Road Sunningdale, Ascot, Berkshire, SL5 0JB, GB"},{"address_street1":"Hurst
+        Grove","address_street2":"Sanford Lane Hurst","address_city":"Reading","address_state":null,"address_postal_code":"RG10
+        0SQ","address_country_code":"GB","address_full":"Hurst Grove, Sanford Lane
+        Hurst, Reading, Berkshire, RG10 0SQ, GB"},{"address_street1":"10 Montpelier
+        Square","address_street2":null,"address_city":"London","address_state":null,"address_postal_code":"SW7
+        1JU","address_country_code":"GB","address_full":"10 Montpelier Square, London,
+        SW7 1JU, GB"},{"address_street1":"Thetford Farm","address_street2":"P.O. Box
+        HP86 Mount Pleasant","address_city":"Harare","address_state":null,"address_postal_code":null,"address_country_code":"ZW","address_full":"Thetford
+        Farm, P.O. Box HP86 Mount Pleasant, Harare, ZW"}]}]}'
+    http_version:
+  recorded_at: Thu, 11 Feb 2016 20:11:13 GMT
+recorded_with: VCR 3.0.1

--- a/spec/cassettes/block_score/candidate/search.yml
+++ b/spec/cassettes/block_score/candidate/search.yml
@@ -136,4 +136,49 @@ http_interactions:
         Farm, P.O. Box HP86 Mount Pleasant, Harare, ZW"}]}]}'
     http_version: 
   recorded_at: Fri, 18 Sep 2015 17:10:41 GMT
-recorded_with: VCR 2.9.3
+- request:
+    method: post
+    uri: https://BLOCKSCORE_TEST_KEY:@api.blockscore.com/
+    body:
+      encoding: UTF-8
+      string: '{"candidate_id":"55fc45903939360003000717"}'
+    headers:
+      Accept:
+      - application/vnd.blockscore+json;version=4
+      User-Agent:
+      - blockscore-ruby/4.2.1 (https://github.com/BlockScore/blockscore-ruby)
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Server:
+      - Cowboy
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Request-Id:
+      - 98109b5a-b276-400d-83f3-99aca9809dcc
+      X-Runtime:
+      - '0.002100'
+      Strict-Transport-Security:
+      - max-age=31536000
+      Date:
+      - Thu, 11 Feb 2016 20:09:41 GMT
+      X-Rack-Cache:
+      - invalidate, pass
+      Set-Cookie:
+      - __profilin=p%3Dt; path=/
+      Content-Length:
+      - '36'
+      Via:
+      - 1.1 vegur
+    body:
+      encoding: UTF-8
+      string: '{"status":"404","error":"Not Found"}'
+    http_version:
+  recorded_at: Thu, 11 Feb 2016 20:09:41 GMT
+recorded_with: VCR 3.0.1

--- a/spec/cassettes/block_score/question_set/create/invalid_person_is_an_invalid_request.yml
+++ b/spec/cassettes/block_score/question_set/create/invalid_person_is_an_invalid_request.yml
@@ -1,0 +1,114 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://BLOCKSCORE_TEST_KEY:@api.blockscore.com/people
+    body:
+      encoding: UTF-8
+      string: '{"name_first":"Jacey","name_last":"Quitzon","document_type":"ssn","document_value":"0001","birth_day":12,"birth_month":12,"birth_year":1975,"address_street1":"295
+        Alexandrea Pass","address_city":"Traceyville","address_subdivision":"IL","address_postal_code":"87346","address_country_code":"US"}'
+    headers:
+      Accept:
+      - application/vnd.blockscore+json;version=4
+      User-Agent:
+      - blockscore-ruby/4.2.1 (https://github.com/BlockScore/blockscore-ruby)
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Server:
+      - Cowboy
+      Connection:
+      - keep-alive
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"9c8a248851faf1d218eb9a8944f37cdd"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 9c460771-6bb4-4622-890d-539c844b5936
+      X-Runtime:
+      - '0.260760'
+      Strict-Transport-Security:
+      - max-age=31536000
+      Date:
+      - Thu, 11 Feb 2016 21:07:55 GMT
+      X-Rack-Cache:
+      - invalidate, pass
+      Set-Cookie:
+      - __profilin=p%3Dt; path=/
+      Transfer-Encoding:
+      - chunked
+      Via:
+      - 1.1 vegur
+    body:
+      encoding: UTF-8
+      string: '{"object":"person","id":"56bcf82b33663300030000bc","created_at":1455224875,"updated_at":1455224875,"status":"invalid","livemode":false,"phone_number":null,"ip_address":null,"birth_day":12,"birth_month":12,"birth_year":1975,"name_first":"Jacey","name_middle":null,"name_last":"Quitzon","address_street1":"295
+        Alexandrea Pass","address_street2":null,"address_city":"Traceyville","address_subdivision":"IL","address_postal_code":"87346","address_country_code":"US","document_type":"ssn","document_value":"0001","note":null,"details":{"address":"no_match","address_risk":"low","identification":"no_match","date_of_birth":"not_found","ofac":"no_match","pep":"no_match"},"question_sets":[]}'
+    http_version:
+  recorded_at: Thu, 11 Feb 2016 21:07:55 GMT
+- request:
+    method: post
+    uri: https://BLOCKSCORE_TEST_KEY:@api.blockscore.com/question_sets
+    body:
+      encoding: UTF-8
+      string: '{"person_id":"56bcf82b33663300030000bc"}'
+    headers:
+      Accept:
+      - application/vnd.blockscore+json;version=4
+      User-Agent:
+      - blockscore-ruby/4.2.1 (https://github.com/BlockScore/blockscore-ruby)
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 400
+      message: Bad Request
+    headers:
+      Server:
+      - Cowboy
+      Connection:
+      - keep-alive
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Content-Type:
+      - application/json; charset=utf-8
+      Cache-Control:
+      - no-cache
+      X-Request-Id:
+      - 1eb47da5-9533-4b38-a481-52967abbf559
+      X-Runtime:
+      - '0.041454'
+      Strict-Transport-Security:
+      - max-age=31536000
+      Date:
+      - Thu, 11 Feb 2016 21:07:56 GMT
+      X-Rack-Cache:
+      - invalidate, pass
+      Set-Cookie:
+      - __profilin=p%3Dt; path=/
+      Transfer-Encoding:
+      - chunked
+      Via:
+      - 1.1 vegur
+    body:
+      encoding: UTF-8
+      string: '{"error":{"type":"invalid_request_error","message":"Id verification
+        can''t be invalid"}}'
+    http_version:
+  recorded_at: Thu, 11 Feb 2016 21:07:56 GMT
+recorded_with: VCR 3.0.1

--- a/spec/cassettes/block_score/question_set/score/incorrect_answers.yml
+++ b/spec/cassettes/block_score/question_set/score/incorrect_answers.yml
@@ -309,4 +309,58 @@ http_interactions:
         at this path (POST /question_sets/55fc709a39613800030008dc)"}}'
     http_version:
   recorded_at: Tue, 09 Feb 2016 02:21:55 GMT
+- request:
+    method: post
+    uri: https://BLOCKSCORE_TEST_KEY:@api.blockscore.com/question_sets55fc709a39613800030008dc/score
+    body:
+      encoding: UTF-8
+      string: '{"answers":[{"question_id":1,"answer_id":2},{"question_id":2,"answer_id":2},{"question_id":3,"answer_id":2},{"question_id":4,"answer_id":0},{"question_id":5,"answer_id":1}]}'
+    headers:
+      Accept:
+      - application/vnd.blockscore+json;version=4
+      User-Agent:
+      - blockscore-ruby/4.2.1 (https://github.com/BlockScore/blockscore-ruby)
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Server:
+      - Cowboy
+      Connection:
+      - keep-alive
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Content-Type:
+      - application/json; charset=utf-8
+      Cache-Control:
+      - no-cache
+      X-Request-Id:
+      - 8008ff0c-b922-48f6-9c2a-e73fff722f90
+      X-Runtime:
+      - '0.005408'
+      Strict-Transport-Security:
+      - max-age=31536000
+      Date:
+      - Thu, 11 Feb 2016 21:07:53 GMT
+      X-Rack-Cache:
+      - invalidate, pass
+      Set-Cookie:
+      - __profilin=p%3Dt; path=/
+      Transfer-Encoding:
+      - chunked
+      Via:
+      - 1.1 vegur
+    body:
+      encoding: UTF-8
+      string: '{"error":{"type":"invalid_request_error","message":"Cannot create requests
+        at this path (POST /question_sets55fc709a39613800030008dc/score)"}}'
+    http_version:
+  recorded_at: Thu, 11 Feb 2016 21:07:53 GMT
 recorded_with: VCR 3.0.1

--- a/spec/cassettes/block_score/question_set/score/incorrect_answers.yml
+++ b/spec/cassettes/block_score/question_set/score/incorrect_answers.yml
@@ -307,7 +307,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"error":{"type":"invalid_request_error","message":"Cannot create requests
         at this path (POST /question_sets/55fc709a39613800030008dc)"}}'
-    http_version:
+    http_version: 
   recorded_at: Tue, 09 Feb 2016 02:21:55 GMT
 - request:
     method: post

--- a/spec/cassettes/block_score/question_set/score/previously_no_answers.yml
+++ b/spec/cassettes/block_score/question_set/score/previously_no_answers.yml
@@ -55,7 +55,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"object":"person","id":"56b91b673565650003000ec0","created_at":1454971751,"updated_at":1454971751,"status":"valid","livemode":false,"phone_number":null,"ip_address":null,"birth_day":12,"birth_month":3,"birth_year":1985,"name_first":"Edythe","name_middle":null,"name_last":"Sipes","address_street1":"695
         Okuneva Garden","address_street2":null,"address_city":"Boganland","address_subdivision":"TN","address_postal_code":"91407-1759","address_country_code":"US","document_type":"ssn","document_value":"0000","note":null,"details":{"address":"no_match","address_risk":"low","identification":"no_match","date_of_birth":"not_found","ofac":"no_match","pep":"no_match"},"question_sets":[]}'
-    http_version:
+    http_version: 
   recorded_at: Mon, 08 Feb 2016 22:49:12 GMT
 - request:
     method: post
@@ -121,7 +121,7 @@ http_interactions:
         is associated with you?","answers":[{"id":1,"answer":"52 Canandaigua Rd"},{"id":2,"answer":"902
         Grass Lake Rd"},{"id":3,"answer":"221 Wolf Lake"},{"id":4,"answer":"309 Colver
         Rd"},{"id":5,"answer":"None Of The Above"}]}]}'
-    http_version:
+    http_version: 
   recorded_at: Mon, 08 Feb 2016 22:49:12 GMT
 - request:
     method: post

--- a/spec/cassettes/block_score/question_set/score/previously_no_answers.yml
+++ b/spec/cassettes/block_score/question_set/score/previously_no_answers.yml
@@ -123,4 +123,58 @@ http_interactions:
         Rd"},{"id":5,"answer":"None Of The Above"}]}]}'
     http_version:
   recorded_at: Mon, 08 Feb 2016 22:49:12 GMT
+- request:
+    method: post
+    uri: https://BLOCKSCORE_TEST_KEY:@api.blockscore.com/question_sets/56b91b683565650003000ec2/score
+    body:
+      encoding: UTF-8
+      string: '{"answers":null}'
+    headers:
+      Accept:
+      - application/vnd.blockscore+json;version=4
+      User-Agent:
+      - blockscore-ruby/4.2.1 (https://github.com/BlockScore/blockscore-ruby)
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 400
+      message: Bad Request
+    headers:
+      Server:
+      - Cowboy
+      Connection:
+      - keep-alive
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Content-Type:
+      - application/json; charset=utf-8
+      Cache-Control:
+      - no-cache
+      X-Request-Id:
+      - 69152496-115a-454e-8cb2-d9c5a4095c11
+      X-Runtime:
+      - '0.020596'
+      Strict-Transport-Security:
+      - max-age=31536000
+      Date:
+      - Thu, 11 Feb 2016 21:07:57 GMT
+      X-Rack-Cache:
+      - invalidate, pass
+      Set-Cookie:
+      - __profilin=p%3Dt; path=/
+      Transfer-Encoding:
+      - chunked
+      Via:
+      - 1.1 vegur
+    body:
+      encoding: UTF-8
+      string: '{"error":{"type":"invalid_request_error","message":"Answers should
+        be an array of objects"}}'
+    http_version:
+  recorded_at: Thu, 11 Feb 2016 21:07:57 GMT
 recorded_with: VCR 3.0.1

--- a/spec/support/error_behavior.rb
+++ b/spec/support/error_behavior.rb
@@ -1,6 +1,6 @@
 RSpec.shared_context 'an error' do
   it do
-    expect { subject.call }.to raise_error do |raised|
+    expect { subject }.to raise_error do |raised|
       expect(raised).to be_an_instance_of(described_class)
       expect(raised.message).to eql(message)
     end

--- a/spec/unit/block_score/api_connection_error_spec.rb
+++ b/spec/unit/block_score/api_connection_error_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe BlockScore::APIConnectionError do
   let(:stubbed_route_pattern) { %r{.*api\.blockscore\.com/people/abc123} }
   let(:stubbed_error) { Errno::ECONNREFUSED }
   let(:message) { 'Connection refused - Exception from WebMock' }
-  subject { -> { BlockScore::Person.retrieve('abc123') } }
+  subject { BlockScore::Person.retrieve('abc123') }
 
   before { stub_request(:get, stubbed_route_pattern).to_raise(stubbed_error) }
 

--- a/spec/unit/block_score/api_connection_error_spec.rb
+++ b/spec/unit/block_score/api_connection_error_spec.rb
@@ -1,12 +1,10 @@
-module BlockScore
-  RSpec.describe APIConnectionError do
-    let(:stubbed_route_pattern) { %r{.*api\.blockscore\.com/people/abc123} }
-    let(:stubbed_error) { Errno::ECONNREFUSED }
-    let(:message) { 'Connection refused - Exception from WebMock' }
-    subject { -> { BlockScore::Person.retrieve('abc123') } }
+RSpec.describe BlockScore::APIConnectionError do
+  let(:stubbed_route_pattern) { %r{.*api\.blockscore\.com/people/abc123} }
+  let(:stubbed_error) { Errno::ECONNREFUSED }
+  let(:message) { 'Connection refused - Exception from WebMock' }
+  subject { -> { BlockScore::Person.retrieve('abc123') } }
 
-    before { stub_request(:get, stubbed_route_pattern).to_raise(stubbed_error) }
+  before { stub_request(:get, stubbed_route_pattern).to_raise(stubbed_error) }
 
-    it_behaves_like 'an error'
-  end
+  it_behaves_like 'an error'
 end

--- a/spec/unit/block_score/base_spec.rb
+++ b/spec/unit/block_score/base_spec.rb
@@ -1,0 +1,41 @@
+require 'faker'
+
+RSpec.describe BlockScore::Base do
+  describe '#save' do
+    context 'when creating a new candidate' do
+      subject(:candidate) { build(:candidate) }
+      before { candidate.save }
+
+      it { is_expected.to be_persisted }
+      its(:name_first) { is_expected.not_to be_empty }
+    end
+
+    context 'when updating an existing candidate' do
+      subject(:candidate) { create(:candidate, name_first: 'John') }
+      before do
+        candidate.name_first = 'Jane'
+        candidate.save
+      end
+
+      it { is_expected.to be_persisted }
+      its(:name_first) { is_expected.to eql 'Jane' }
+    end
+  end
+
+  describe '#refresh' do
+    subject(:candidate) { create(:candidate, name_last: 'Smith') }
+    before do
+      candidate.name_last = 'John'
+      candidate.refresh
+    end
+
+    its(:name_last) { is_expected.to eql 'Smith' }
+  end
+
+  describe '#inspect' do
+    subject(:candidate_inspection) { create(:candidate).inspect }
+
+    it { is_expected.to be_an_instance_of String }
+    it { is_expected.to match(/\A#<BlockScore::Candidate:0x/) }
+  end
+end

--- a/spec/unit/block_score/candidate_spec.rb
+++ b/spec/unit/block_score/candidate_spec.rb
@@ -1,137 +1,121 @@
 require 'faker'
 
-module BlockScore
-  RSpec.describe Candidate do
-    describe '.new' do
-      subject(:candidate) { BlockScore::Candidate.new(attributes_for(:candidate)) }
+RSpec.describe BlockScore::Candidate do
+  describe '.new' do
+    subject(:candidate) { described_class.new(attributes_for(:candidate)) }
 
-      it { is_expected.not_to be_persisted }
-      its(:class) { should be BlockScore::Candidate }
+    it { is_expected.not_to be_persisted }
+    it { is_expected.to be_an_instance_of described_class }
+  end
+
+  describe '.create' do
+    subject(:candidate) { described_class.create(attributes_for(:candidate)) }
+
+    it { is_expected.to be_persisted }
+    it { is_expected.to be_an_instance_of described_class }
+  end
+
+  describe '.retrieve' do
+    let(:candidate_id) { create(:candidate).id }
+    subject(:candidate) { described_class.retrieve(candidate_id) }
+
+    it { is_expected.to be_persisted }
+    its(:name_first) { is_expected.not_to be_empty }
+    it { is_expected.to be_an_instance_of described_class }
+  end
+
+  # NB: At the time of writing, the testing API does not reset. Making this
+  #     test less then perfect. To work around the near certain availability
+  #     of historical candidates from other tests known candidates are created
+  #     and checked. This has the side effect of being susceptible to race
+  #     conditions if tested against the live API in parallel.
+  describe '.all' do
+    let(:uniq_token_one) { '05816347d2234ef4a92465e9784c7ce1' }
+    let(:uniq_token_two) { 'b4cd5fb645788c3b37c11407b83d7741' }
+    subject(:candidates) { described_class.all }
+
+    before do
+      create(:candidate, name_first: 'John', name_last: uniq_token_one)
+      create(:candidate, name_first: 'John', name_last: uniq_token_two)
     end
 
-    describe '.create' do
-      subject(:candidate) { BlockScore::Candidate.create(attributes_for(:candidate)) }
+    it { is_expected.not_to be_empty }
+    it { expect(candidates[0].name_last).to eql uniq_token_two }
+    it { expect(candidates[1].name_last).to eql uniq_token_one }
+  end
 
-      it { is_expected.to be_persisted }
-      its(:class) { should be BlockScore::Candidate }
-    end
-
-    describe '.retrieve' do
-      let(:candidate_id)  { create(:candidate).id }
-      subject(:candidate) { BlockScore::Candidate.retrieve(candidate_id) }
+  describe '#save' do
+    context 'when creating a new candidate' do
+      subject(:candidate) { build(:candidate) }
+      before { candidate.save }
 
       it { is_expected.to be_persisted }
       its(:name_first) { is_expected.not_to be_empty }
-      its(:class) { should be BlockScore::Candidate }
     end
 
-    # NB: At the time of writing, the testing API does not reset. Making this
-    #     test less then perfect. To work around the near certain availability
-    #     of historical candidates from other tests known candidates are created
-    #     and checked. This has the side effect of being susceptible to race
-    #     conditions if tested against the live API in parallel.
-    describe '.all' do
-      let(:uniq_token_one) { '05816347d2234ef4a92465e9784c7ce1' }
-      let(:uniq_token_two) { 'b4cd5fb645788c3b37c11407b83d7741' }
-      subject(:candidates) { BlockScore::Candidate.all }
-
+    context 'when updating an existing candidate' do
+      subject(:candidate) { create(:candidate, name_first: 'John') }
       before do
-        create(:candidate, name_first: 'John', name_last: uniq_token_one)
-        create(:candidate, name_first: 'John', name_last: uniq_token_two)
-      end
-
-      it { is_expected.not_to be_empty }
-      it { expect(candidates[0].name_last).to eql uniq_token_two }
-      it { expect(candidates[1].name_last).to eql uniq_token_one }
-    end
-
-    describe '#save' do
-      context 'when creating a new candidate' do
-        subject(:candidate) { build(:candidate) }
-        before { candidate.save }
-
-        it { is_expected.to be_persisted }
-        its(:name_first) { is_expected.not_to be_empty }
-      end
-
-      context 'when updating an existing candidate' do
-        subject(:candidate) { create(:candidate, name_first: 'John') }
-        before do
-          candidate.name_first = 'Jane'
-          candidate.save
-        end
-
-        it { is_expected.to be_persisted }
-        its(:name_first) { is_expected.to eql 'Jane' }
-      end
-    end
-
-    describe '#refresh' do
-      subject(:candidate) { create(:candidate, name_last: 'Smith') }
-      before do
-        candidate.name_last = 'John'
-        candidate.refresh
-      end
-
-      its(:name_last) { is_expected.to eql 'Smith' }
-    end
-
-    describe '#inspect' do
-      subject(:candidate_inspection) { create(:candidate).inspect }
-
-      its(:class) { should be String }
-      it { is_expected.to match(/^#<BlockScore::Candidate:0x/) }
-    end
-
-    describe '#delete' do
-      subject(:candidate) { create(:candidate) }
-      let(:candidate_id)  { candidate.id }
-      before { candidate.delete }
-
-      it { is_expected.not_to be_persisted }
-      it { expect(candidate.deleted).to be true }
-    end
-
-    describe '#history' do
-      subject(:candidate) { create(:candidate, name_first: 'version_0') }
-      before do
-        candidate.name_first = 'version_1'
-        candidate.save
-
-        candidate.name_first = 'version_2'
+        candidate.name_first = 'Jane'
         candidate.save
       end
 
-      its(:history) { is_expected.not_to be_empty }
-      it { expect(candidate.history[0].class).to be BlockScore::Candidate }
-      it { expect(candidate.history[0].name_first).to eql 'version_2' }
-      it { expect(candidate.history[1].name_first).to eql 'version_1' }
-      it { expect(candidate.history[2].name_first).to eql 'version_0' }
+      it { is_expected.to be_persisted }
+      its(:name_first) { is_expected.to eql 'Jane' }
+    end
+  end
+
+  describe '#delete' do
+    subject(:candidate) { create(:candidate) }
+    let(:candidate_id) { candidate.id }
+    before { candidate.delete }
+
+    it { is_expected.not_to be_persisted }
+    it { expect(candidate.deleted).to be true }
+  end
+
+  describe '#history' do
+    subject(:candidate) { create(:candidate, name_first: 'version_0') }
+    before do
+      candidate.name_first = 'version_1'
+      candidate.save
+
+      candidate.name_first = 'version_2'
+      candidate.save
     end
 
-    describe '#hits' do
-      subject(:candidate) { create(:watched_candidate) }
-      before do
-        candidate.search
+    its(:history) { is_expected.not_to be_empty }
+    it { expect(candidate.history[0].class).to be described_class }
+    it { expect(candidate.history[0].name_first).to eql 'version_2' }
+    it { expect(candidate.history[1].name_first).to eql 'version_1' }
+    it { expect(candidate.history[2].name_first).to eql 'version_0' }
+  end
 
-        # ==================================================
-        # Micro Patch: Spinlock until delay job has processed.
-        #
-        # After a new recording, the empty responses should be edited out to
-        #   prevent baking in the sleeps, as they will be replayed in order.
-        VCRHelper.spinlock_until { candidate.hits.count != 0 }
-        # ==================================================
-      end
+  describe '#hits' do
+    subject(:candidate) { create(:watched_candidate) }
+    before do
+      candidate.search
 
-      its(:hits) { is_expected.not_to be_empty }
-      it { expect(candidate.hits.first).to be_an_instance_of BlockScore::WatchlistHit }
+      # ==================================================
+      # Micro Patch: Spinlock until delay job has processed.
+      #
+      # After a new recording, the empty responses should be edited out to
+      #   prevent baking in the sleeps, as they will be replayed in order.
+      VCRHelper.spinlock_until { candidate.hits.count != 0 }
+      # ==================================================
     end
 
-    describe '#search' do
-      subject(:candidate_search) { create(:watched_candidate).search }
-
-      it { is_expected.not_to be_empty }
-      it { expect(candidate_search.first).to be_an_instance_of BlockScore::WatchlistHit }
+    its(:hits) { is_expected.not_to be_empty }
+    it 'returns a watchlist hit' do
+      expect(candidate.hits)
+        .to all(be_an_instance_of BlockScore::WatchlistHit)
     end
+  end
+
+  describe '#search' do
+    subject(:candidate_search) { create(:watched_candidate).search }
+
+    it { is_expected.not_to be_empty }
+    it { is_expected.to all(be_an_instance_of BlockScore::WatchlistHit) }
   end
 end

--- a/spec/unit/block_score/candidate_spec.rb
+++ b/spec/unit/block_score/candidate_spec.rb
@@ -101,7 +101,7 @@ RSpec.describe BlockScore::Candidate do
       #
       # After a new recording, the empty responses should be edited out to
       #   prevent baking in the sleeps, as they will be replayed in order.
-      VCRHelper.spinlock_until { candidate.hits.count != 0 }
+      VCRHelper.spinlock_until { candidate.hits.any? }
       # ==================================================
     end
 

--- a/spec/unit/block_score/candidate_spec.rb
+++ b/spec/unit/block_score/candidate_spec.rb
@@ -32,12 +32,9 @@ RSpec.describe BlockScore::Candidate do
   describe '.all' do
     let(:uniq_token_one) { '05816347d2234ef4a92465e9784c7ce1' }
     let(:uniq_token_two) { 'b4cd5fb645788c3b37c11407b83d7741' }
+    let!(:c1) { create(:candidate, name_first: 'John', name_last: uniq_token_one) }
+    let!(:c2) { create(:candidate, name_first: 'John', name_last: uniq_token_two) }
     subject(:candidates) { described_class.all }
-
-    before do
-      create(:candidate, name_first: 'John', name_last: uniq_token_one)
-      create(:candidate, name_first: 'John', name_last: uniq_token_two)
-    end
 
     it { is_expected.not_to be_empty }
     it { expect(candidates[0].name_last).to eql uniq_token_two }

--- a/spec/unit/block_score/collection/member_spec.rb
+++ b/spec/unit/block_score/collection/member_spec.rb
@@ -1,32 +1,28 @@
-module BlockScore
-  class Collection
-    RSpec.describe Member do
-      describe '#save' do
-        let(:question_set) { QuestionSet.new }
-        subject(:member) { described_class.new(person, question_set) }
+RSpec.describe BlockScore::Collection::Member do
+  describe '#save' do
+    let(:question_set) { BlockScore::QuestionSet.new }
+    subject(:member) { described_class.new(person, question_set) }
 
-        context 'unsaved person' do
-          let(:person) { BlockScore::Person.new(attributes_for(:person)) }
+    context 'unsaved person' do
+      let(:person) { BlockScore::Person.new(attributes_for(:person)) }
 
-          it 'saves the person as part of member save' do
-            expect(person).to_not be_persisted
-            expect(member.save).to be true
-            expect(person).to be_persisted
-          end
-        end
+      it 'saves the person as part of member save' do
+        expect(person).to_not be_persisted
+        expect(member.save).to be true
+        expect(person).to be_persisted
+      end
+    end
 
-        context 'previously saved person' do
-          let(:person) { BlockScore::Person.create(attributes_for(:person)) }
+    context 'previously saved person' do
+      let(:person) { BlockScore::Person.create(attributes_for(:person)) }
 
-          it 'contains the proper fields' do
-            expect(member.save).to be true
-            expect(person).to be_persisted
-            expect(person.attributes.fetch(:question_sets))
-              .to eql([question_set.id])
-            expect(member).to be_an_instance_of described_class
-            expect(member.person_id).to eql person.id
-          end
-        end
+      it 'contains the proper fields' do
+        expect(member.save).to be true
+        expect(person).to be_persisted
+        expect(person.attributes.fetch(:question_sets))
+          .to eql([question_set.id])
+        expect(member).to be_an_instance_of described_class
+        expect(member.person_id).to eql person.id
       end
     end
   end

--- a/spec/unit/block_score/collection_spec.rb
+++ b/spec/unit/block_score/collection_spec.rb
@@ -1,48 +1,45 @@
-module BlockScore
-  RSpec.describe Collection do
-    let(:person) { create(:person) }
-    subject(:question_sets) { person.question_sets }
+RSpec.describe BlockScore::Collection do
+  let(:person) { create(:person) }
+  subject(:question_sets) { person.question_sets }
+
+  it { is_expected.to be_empty }
+  its(:class) { should be described_class }
+
+  describe '.all' do
+    it { is_expected.to be_empty }
+    it { expect(question_sets.all.class).to be described_class }
+  end
+
+  describe '.new' do
+    before { question_sets.new }
+
+    it { is_expected.not_to be_empty }
+    its(:count) { should be 1 }
+    its(:class) { should be described_class }
+  end
+
+  describe '.refresh' do
+    before do
+      question_sets.new
+      question_sets.new
+      question_sets.refresh
+    end
 
     it { is_expected.to be_empty }
-    its(:class) { should be BlockScore::Collection }
+    its(:class) { should be described_class }
+  end
 
-    describe '.all' do
-      it { is_expected.to be_empty }
-      it { expect(question_sets.all.class).to be BlockScore::Collection }
-    end
+  describe '.create' do
+    before { question_sets.create }
 
-    describe '.new' do
-      before { question_sets.new }
+    it { is_expected.not_to be_empty }
+    its(:count) { should be 1 }
+    its(:class) { should be described_class }
+  end
 
-      it { is_expected.not_to be_empty }
-      its(:count) { should be 1 }
-      its(:class) { should be BlockScore::Collection }
-    end
+  describe '.retrieve' do
+    let(:question_set_id) { create(:question_set, person_id: person.id).id }
 
-    describe '.refresh' do
-      before do
-        question_sets.new
-        question_sets.new
-        question_sets.refresh
-      end
-
-      it { is_expected.to be_empty }
-      its(:class) { should be BlockScore::Collection }
-    end
-
-    describe '.create' do
-      before { question_sets.create }
-
-      it { is_expected.not_to be_empty }
-      its(:count) { should be 1 }
-      its(:class) { should be BlockScore::Collection }
-    end
-
-    describe '.retrieve' do
-      let(:question_set_id) { create(:question_set, person_id: person.id).id }
-
-      it { expect(question_sets.retrieve(question_set_id).nil?).to be false }
-      it { expect(question_sets.retrieve(question_set_id).class).to be BlockScore::Collection::Member }
-    end
+    it { expect(question_sets.retrieve(question_set_id).class).to be BlockScore::Collection::Member }
   end
 end

--- a/spec/unit/block_score/company_spec.rb
+++ b/spec/unit/block_score/company_spec.rb
@@ -1,80 +1,60 @@
-module BlockScore
-  RSpec.describe Company do
-    describe '.new' do
-      subject(:company) { BlockScore::Company.new(attributes_for(:company)) }
+RSpec.describe BlockScore::Company do
+  describe '.new' do
+    subject(:company) { described_class.new(attributes_for(:company)) }
 
-      it { is_expected.not_to be_persisted }
-      its(:class) { should be BlockScore::Company }
-    end
+    it { is_expected.not_to be_persisted }
+    it { is_expected.to be_an_instance_of described_class }
+  end
 
-    describe '.create' do
-      context 'valid company' do
-        subject(:company) { BlockScore::Company.create(attributes_for(:company)) }
-
-        it { is_expected.to be_persisted }
-        its(:class) { should be BlockScore::Company }
-      end
-
-      context 'invalid company' do
-        subject(:company) { BlockScore::Company.create(attributes_for(:invalid_company)) }
-
-        it { is_expected.to be_persisted }
-        its(:class) { should be BlockScore::Company }
-      end
-    end
-
-    describe '.retrieve' do
-      let(:company_id)  { create(:company).id }
-      subject(:company) { BlockScore::Company.retrieve(company_id) }
+  describe '.create' do
+    context 'valid company' do
+      subject(:company) { described_class.create(attributes_for(:company)) }
 
       it { is_expected.to be_persisted }
-      its(:entity_name) { is_expected.not_to be_empty }
-      its(:class) { should be BlockScore::Company }
+      it { is_expected.to be_an_instance_of described_class }
     end
 
-    describe '.all' do
-      let(:uniq_token_one) { '4580ab610751f6f37078329357ff98db' }
-      let(:uniq_token_two) { '0f222bcb487f9de689c5c60b854973bc' }
-      subject(:companies) { BlockScore::Company.all }
-
-      before do
-        create(:company, entity_name: uniq_token_one)
-        create(:company, entity_name: uniq_token_two)
-      end
-
-      it { is_expected.not_to be_empty }
-      it { expect(companies[0].entity_name).to eq uniq_token_two }
-      it { expect(companies[1].entity_name).to eq uniq_token_one }
-    end
-
-    describe '#refresh' do
-      subject(:company) { create(:company, entity_name: 'BlockScore') }
-      before do
-        company.entity_name = 'DarkScore'
-        company.refresh
-      end
-
-      its(:entity_name) { is_expected.to eq 'BlockScore' }
-    end
-
-    describe '#inspect' do
-      subject(:company_inspection) { create(:company).inspect }
-
-      its(:class) { should be(String) }
-      it { is_expected.to match(/^#<BlockScore::Company:0x/) }
-    end
-
-    describe '#delete' do
-      subject(:company) { create(:company) }
-      it { expect { company.delete }.to raise_error NoMethodError }
-    end
-
-    describe '#save' do
-      subject(:company) { build(:company) }
-      before { company.save }
+    context 'invalid company' do
+      subject(:company) { described_class.create(attributes_for(:invalid_company)) }
 
       it { is_expected.to be_persisted }
-      its(:class) { should be BlockScore::Company }
+      it { is_expected.to be_an_instance_of described_class }
     end
+  end
+
+  describe '.retrieve' do
+    let(:company_id) { create(:company).id }
+    subject(:company) { described_class.retrieve(company_id) }
+
+    it { is_expected.to be_persisted }
+    its(:entity_name) { is_expected.not_to be_empty }
+    it { is_expected.to be_an_instance_of described_class }
+  end
+
+  describe '.all' do
+    let(:uniq_token_one) { '4580ab610751f6f37078329357ff98db' }
+    let(:uniq_token_two) { '0f222bcb487f9de689c5c60b854973bc' }
+    subject(:companies) { described_class.all }
+
+    before do
+      create(:company, entity_name: uniq_token_one)
+      create(:company, entity_name: uniq_token_two)
+    end
+
+    it { expect(companies[0].entity_name).to eql uniq_token_two }
+    it { expect(companies[1].entity_name).to eql uniq_token_one }
+  end
+
+  describe '#delete' do
+    subject(:company) { create(:company) }
+    it { expect { company.delete }.to raise_error NoMethodError }
+  end
+
+  describe '#save' do
+    subject(:company) { build(:company) }
+    before { company.save }
+
+    it { is_expected.to be_persisted }
+    it { is_expected.to be_an_instance_of described_class }
   end
 end

--- a/spec/unit/block_score/company_spec.rb
+++ b/spec/unit/block_score/company_spec.rb
@@ -34,12 +34,9 @@ RSpec.describe BlockScore::Company do
   describe '.all' do
     let(:uniq_token_one) { '4580ab610751f6f37078329357ff98db' }
     let(:uniq_token_two) { '0f222bcb487f9de689c5c60b854973bc' }
+    let!(:c1) { create(:company, entity_name: uniq_token_one) }
+    let!(:c2) { create(:company, entity_name: uniq_token_two) }
     subject(:companies) { described_class.all }
-
-    before do
-      create(:company, entity_name: uniq_token_one)
-      create(:company, entity_name: uniq_token_two)
-    end
 
     it { expect(companies[0].entity_name).to eql uniq_token_two }
     it { expect(companies[1].entity_name).to eql uniq_token_one }

--- a/spec/unit/block_score/invalid_request_error_spec.rb
+++ b/spec/unit/block_score/invalid_request_error_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe BlockScore::InvalidRequestError do
-  subject { -> { BlockScore::Person.create(first_name: 'John') } }
+  subject { BlockScore::Person.create(first_name: 'John') }
   let(:message) do
     '(Type: invalid_request_error) ' \
     'One or more required parameters are invalid (name_first) (Status: 400)'

--- a/spec/unit/block_score/invalid_request_error_spec.rb
+++ b/spec/unit/block_score/invalid_request_error_spec.rb
@@ -1,10 +1,9 @@
-module BlockScore
-  RSpec.describe InvalidRequestError do
-    subject { -> { BlockScore::Person.create(first_name: 'John') } }
-    let(:message) do
-      '(Type: invalid_request_error) One or more required parameters are invalid (name_first) (Status: 400)'
-    end
-
-    it_behaves_like 'an error'
+RSpec.describe BlockScore::InvalidRequestError do
+  subject { -> { BlockScore::Person.create(first_name: 'John') } }
+  let(:message) do
+    '(Type: invalid_request_error) ' \
+    'One or more required parameters are invalid (name_first) (Status: 400)'
   end
+
+  it_behaves_like 'an error'
 end

--- a/spec/unit/block_score/not_found_error_spec.rb
+++ b/spec/unit/block_score/not_found_error_spec.rb
@@ -1,10 +1,9 @@
-module BlockScore
-  RSpec.describe NotFoundError do
-    subject { -> { BlockScore::Person.retrieve('abc123') } }
-    let(:message) do
-      '(Type: invalid_request_error) Person with id abc123 could not be found (Status: 404)'
-    end
-
-    it_behaves_like 'an error'
+RSpec.describe BlockScore::NotFoundError do
+  subject { -> { BlockScore::Person.retrieve('abc123') } }
+  let(:message) do
+    '(Type: invalid_request_error) ' \
+    'Person with id abc123 could not be found (Status: 404)'
   end
+
+  it_behaves_like 'an error'
 end

--- a/spec/unit/block_score/not_found_error_spec.rb
+++ b/spec/unit/block_score/not_found_error_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe BlockScore::NotFoundError do
-  subject { -> { BlockScore::Person.retrieve('abc123') } }
+  subject { BlockScore::Person.retrieve('abc123') }
   let(:message) do
     '(Type: invalid_request_error) ' \
     'Person with id abc123 could not be found (Status: 404)'

--- a/spec/unit/block_score/person_spec.rb
+++ b/spec/unit/block_score/person_spec.rb
@@ -1,135 +1,114 @@
-module BlockScore
-  RSpec.describe Person do
-    describe '.new' do
-      let(:attrs)      { attributes_for(:person) }
-      subject(:person) { BlockScore::Person.new(attrs) }
+RSpec.describe BlockScore::Person do
+  describe '.new' do
+    subject(:person) { described_class.new(attributes_for(:person)) }
 
-      it { is_expected.not_to be_persisted }
-      its(:class) { should be BlockScore::Person }
-      its(:question_sets) { should be_an_instance_of BlockScore::Collection }
-    end
+    it { is_expected.not_to be_persisted }
+    it { is_expected.to be_an_instance_of described_class }
+  end
 
-    describe '.create' do
-      context 'valid person' do
-        subject(:person) { BlockScore::Person.create(attributes_for(:person)) }
-
-        it { is_expected.to be_persisted }
-        its(:class) { should be BlockScore::Person }
-      end
-
-      context 'invalid person' do
-        subject(:person) { BlockScore::Person.create(attributes_for(:invalid_person)) }
-
-        it { is_expected.to be_persisted }
-        its(:class) { should be BlockScore::Person }
-      end
-    end
-
-    describe '.retrieve' do
-      let(:person_id)  { create(:person).id }
-      subject(:person) { BlockScore::Person.retrieve(person_id) }
+  describe '.create' do
+    context 'valid person' do
+      subject(:person) { described_class.create(attributes_for(:person)) }
 
       it { is_expected.to be_persisted }
-      its(:name_first) { is_expected.not_to be_empty }
-      its(:class) { should be BlockScore::Person }
-      context 'null id presented' do
-        let(:person_id) { nil }
-
-        it { expect { BlockScore::Person.retrieve(person_id) }.to raise_error(ArgumentError, 'ID must be supplied') }
-      end
-
-      context 'empty id presented' do
-        let(:person_id) { '' }
-
-        it { expect { BlockScore::Person.retrieve(person_id) }.to raise_error(ArgumentError, 'ID must be supplied') }
-      end
-
-      context 'Malformed ID presented' do
-        let(:person_id) { 'ABC&&234' }
-
-        it { expect { BlockScore::Person.retrieve(person_id) }.to raise_error(ArgumentError, 'ID is malformed') }
-      end
+      it { is_expected.to be_an_instance_of described_class }
     end
 
-    describe '.all' do
-      let(:uniq_token_one) { '4c2c019a1e3c33442644d9f52c7a93f7' }
-      let(:uniq_token_two) { 'b19a680671c6c006c6105aa450837668' }
-      subject(:people) { BlockScore::Person.all }
-
-      before do
-        create(:person, name_first: 'John', name_last: uniq_token_one)
-        create(:person, name_first: 'John', name_last: uniq_token_two)
-      end
-
-      it { is_expected.not_to be_empty }
-      it { expect(people[0].name_last).to eq uniq_token_two }
-      it { expect(people[1].name_last).to eq uniq_token_one }
-    end
-
-    describe '#valid?' do
-      context 'valid person' do
-        subject(:person) { create(:valid_person) }
-
-        it { is_expected.to be_persisted }
-        it { is_expected.to be_valid }
-        its(:class) { should be BlockScore::Person }
-      end
-
-      context 'invalid person' do
-        subject(:person) { create(:invalid_person) }
-
-        it { is_expected.to be_persisted }
-        it { is_expected.not_to be_valid }
-        its(:class) { should be BlockScore::Person }
-      end
-    end
-
-    describe '#invalid?' do
-      context 'valid person' do
-        subject(:person) { create(:valid_person) }
-
-        it { is_expected.to be_persisted }
-        it { is_expected.not_to be_invalid }
-        its(:class) { should be BlockScore::Person }
-      end
-
-      context 'invalid person' do
-        subject(:person) { create(:invalid_person) }
-
-        it { is_expected.to be_persisted }
-        it { is_expected.to be_invalid }
-        its(:class) { should be BlockScore::Person }
-      end
-    end
-
-    describe '#refresh' do
-      subject(:person) { create(:person, name_first: 'John') }
-      before do
-        person.name_first = 'Mike'
-        person.refresh
-      end
-
-      it { expect(person.name_first).to eq 'John' }
-    end
-
-    describe '#inspect' do
-      subject(:person_inspection) { create(:person).inspect }
-
-      its(:class) { should be(String) }
-      it { is_expected.to match(/^#<BlockScore::Person:0x/) }
-    end
-
-    describe '#delete' do
-      subject(:person) { create(:person) }
-      it { expect { person.delete }.to raise_error NoMethodError }
-    end
-
-    describe '#save' do
-      subject(:person) { build(:person) }
-      before { person.save }
+    context 'invalid person' do
+      subject(:person) { described_class.create(attributes_for(:invalid_person)) }
 
       it { is_expected.to be_persisted }
-      its(:class) { should be BlockScore::Person }
+      it { is_expected.to be_an_instance_of described_class }
     end
+  end
+
+  describe '.retrieve' do
+    let(:person_id) { create(:person).id }
+    subject(:person) { described_class.retrieve(person_id) }
+
+    it { is_expected.to be_persisted }
+    its(:name_first) { is_expected.not_to be_empty }
+    it { is_expected.to be_an_instance_of described_class }
+    context 'null id presented' do
+      let(:person_id) { nil }
+
+      it { expect { described_class.retrieve(person_id) }.to raise_error(ArgumentError, 'ID must be supplied') }
+    end
+
+    context 'empty id presented' do
+      let(:person_id) { '' }
+
+      it { expect { described_class.retrieve(person_id) }.to raise_error(ArgumentError, 'ID must be supplied') }
+    end
+
+    context 'Malformed ID presented' do
+      let(:person_id) { 'ABC&&234' }
+
+      it { expect { described_class.retrieve(person_id) }.to raise_error(ArgumentError, 'ID is malformed') }
+    end
+  end
+
+  describe '.all' do
+    let(:uniq_token_one) { '4c2c019a1e3c33442644d9f52c7a93f7' }
+    let(:uniq_token_two) { 'b19a680671c6c006c6105aa450837668' }
+    subject(:people) { described_class.all }
+
+    before do
+      create(:person, name_first: 'John', name_last: uniq_token_one)
+      create(:person, name_first: 'John', name_last: uniq_token_two)
+    end
+
+    it { is_expected.not_to be_empty }
+    it { expect(people[0].name_last).to eql uniq_token_two }
+    it { expect(people[1].name_last).to eql uniq_token_one }
+  end
+
+  describe '#valid?' do
+    context 'valid person' do
+      subject(:person) { create(:valid_person) }
+
+      it { is_expected.to be_persisted }
+      it { is_expected.to be_valid }
+      it { is_expected.to be_an_instance_of described_class }
+    end
+
+    context 'invalid person' do
+      subject(:person) { create(:invalid_person) }
+
+      it { is_expected.to be_persisted }
+      it { is_expected.not_to be_valid }
+      it { is_expected.to be_an_instance_of described_class }
+    end
+  end
+
+  describe '#invalid?' do
+    context 'valid person' do
+      subject(:person) { create(:valid_person) }
+
+      it { is_expected.to be_persisted }
+      it { is_expected.not_to be_invalid }
+      it { is_expected.to be_an_instance_of described_class }
+    end
+
+    context 'invalid person' do
+      subject(:person) { create(:invalid_person) }
+
+      it { is_expected.to be_persisted }
+      it { is_expected.to be_invalid }
+      it { is_expected.to be_an_instance_of described_class }
+    end
+  end
+
+  describe '#delete' do
+    subject(:person) { create(:person) }
+    it { expect { person.delete }.to raise_error NoMethodError }
+  end
+
+  describe '#save' do
+    subject(:person) { build(:person) }
+    before { person.save }
+
+    it { is_expected.to be_persisted }
+    it { is_expected.to be_an_instance_of described_class }
   end
 end

--- a/spec/unit/block_score/person_spec.rb
+++ b/spec/unit/block_score/person_spec.rb
@@ -51,12 +51,9 @@ RSpec.describe BlockScore::Person do
   describe '.all' do
     let(:uniq_token_one) { '4c2c019a1e3c33442644d9f52c7a93f7' }
     let(:uniq_token_two) { 'b19a680671c6c006c6105aa450837668' }
+    let!(:p1) { create(:person, name_first: 'John', name_last: uniq_token_one) }
+    let!(:p2) { create(:person, name_first: 'John', name_last: uniq_token_two) }
     subject(:people) { described_class.all }
-
-    before do
-      create(:person, name_first: 'John', name_last: uniq_token_one)
-      create(:person, name_first: 'John', name_last: uniq_token_two)
-    end
 
     it { is_expected.not_to be_empty }
     it { expect(people[0].name_last).to eql uniq_token_two }

--- a/spec/unit/block_score/question_set_spec.rb
+++ b/spec/unit/block_score/question_set_spec.rb
@@ -1,98 +1,82 @@
-module BlockScore
-  RSpec.describe QuestionSet do
-    describe '.new' do
-      subject(:question_set) { BlockScore::QuestionSet.new }
+RSpec.describe BlockScore::QuestionSet do
+  describe '.new' do
+    subject(:question_set) { described_class.new }
 
-      it { is_expected.not_to be_persisted }
-      its(:class) { should be BlockScore::QuestionSet }
-    end
+    it { is_expected.not_to be_persisted }
+    it { is_expected.to be_an_instance_of described_class }
+  end
 
-    describe '.create' do
-      context 'valid person' do
-        let(:person_id) { create(:valid_person).id }
-        subject(:question_set) { BlockScore::QuestionSet.create(person_id: person_id) }
-
-        it { is_expected.to be_persisted }
-        its(:class) { should be BlockScore::QuestionSet }
-      end
-
-      context 'invalid person' do
-        let(:person_id) { create(:invalid_person).id }
-
-        it { expect { BlockScore::QuestionSet.create(person_id: person_id) }.to raise_error BlockScore::InvalidRequestError }
-      end
-    end
-
-    describe '.retrieve' do
-      let(:question_set_id) { create(:question_set).id }
-      subject(:question_set) { BlockScore::QuestionSet.retrieve(question_set_id) }
+  describe '.create' do
+    context 'valid person' do
+      let(:person_id) { create(:valid_person).id }
+      subject(:question_set) { described_class.create(person_id: person_id) }
 
       it { is_expected.to be_persisted }
-      its(:questions) { is_expected.not_to be_empty }
-      its(:class) { should be BlockScore::QuestionSet }
+      it { is_expected.to be_an_instance_of described_class }
     end
 
-    describe '#score' do
-      subject(:question_set) { create(:question_set) }
-      let(:correct_answers) { QuestionSetHelper.correct_answers(question_set.questions) }
-      let(:incorrect_answers) { QuestionSetHelper.incorrect_answers(question_set.questions) }
+    context 'invalid person' do
+      let(:person_id) { create(:invalid_person).id }
 
-      context 'correct answers' do
-        it { expect(question_set.score(correct_answers)).to be 100.0 }
+      it 'is an invalid request' do
+        expect { described_class.create(person_id: person_id) }
+          .to raise_error BlockScore::InvalidRequestError
       end
+    end
+  end
 
-      context 'incorrect answers' do
-        it { expect(question_set.score(incorrect_answers)).to be 0.0 }
-      end
+  describe '.retrieve' do
+    let(:question_set_id) { create(:question_set).id }
+    subject(:question_set) { described_class.retrieve(question_set_id) }
 
-      context 'malformed answers' do
-        it 'raises an error when answers are not an array of hashes' do
-          expect { question_set.score([]) }
-            .to raise_error InvalidRequestError, \
-                            '(Type: invalid_request_error) ' \
+    it { is_expected.to be_persisted }
+    its(:questions) { is_expected.not_to be_empty }
+    it { is_expected.to be_an_instance_of described_class }
+  end
+
+  describe '#score' do
+    subject(:question_set) { create(:question_set) }
+    let(:correct_answers) { QuestionSetHelper.correct_answers(question_set.questions) }
+    let(:incorrect_answers) { QuestionSetHelper.incorrect_answers(question_set.questions) }
+
+    context 'correct answers' do
+      it { expect(question_set.score(correct_answers)).to be 100.0 }
+    end
+
+    context 'incorrect answers' do
+      it { expect(question_set.score(incorrect_answers)).to be 0.0 }
+    end
+
+    context 'malformed answers' do
+      it 'raises an error when answers are not an array of hashes' do
+        expect { question_set.score([]) }
+          .to raise_error BlockScore::InvalidRequestError,
+                          '(Type: invalid_request_error) ' \
                             'Answers should be an array of objects  (Status: 400)'
-        end
-      end
-
-      context 'previous answers' do
-        before { question_set.score(correct_answers) }
-
-        it { expect(question_set.score).to be 100.0 }
-      end
-
-      context 'previously no answers' do
-        it { expect(question_set.score).to be nil }
       end
     end
 
-    describe '#refresh' do
-      subject(:question_set) { create(:question_set) }
-      before do
-        question_set.questions = nil
-        question_set.refresh
-      end
+    context 'previous answers' do
+      before { question_set.score(correct_answers) }
 
-      its(:questions) { is_expected.not_to be_empty }
+      it { expect(question_set.score).to be(100.0) }
     end
 
-    describe '#inspect' do
-      subject(:question_set_inspection) { create(:question_set).inspect }
-
-      its(:class) { should be(String) }
-      it { is_expected.to match(/^#<BlockScore::QuestionSet:0x/) }
+    context 'previously no answers' do
+      it { expect(question_set.score).to be nil }
     end
+  end
 
-    describe '#delete' do
-      subject(:question_set) { create(:question_set) }
-      it { expect { question_set.delete }.to raise_error NoMethodError }
-    end
+  describe '#delete' do
+    subject(:question_set) { create(:question_set) }
+    it { expect { question_set.delete }.to raise_error NoMethodError }
+  end
 
-    describe '#save' do
-      subject(:question_set) { build(:question_set) }
-      before { question_set.save }
+  describe '#save' do
+    subject(:question_set) { build(:question_set) }
+    before { question_set.save }
 
-      it { is_expected.to be_persisted }
-      its(:class) { should be BlockScore::QuestionSet }
-    end
+    it { is_expected.to be_persisted }
+    it { is_expected.to be_an_instance_of described_class }
   end
 end

--- a/spec/unit/block_score/util_spec.rb
+++ b/spec/unit/block_score/util_spec.rb
@@ -100,10 +100,10 @@ RSpec.describe BlockScore::Util do
           'If this problem persists, please message support@blockscore.com.'
       end
       let(:input) { '{{' }
-      subject(:parse_attempt) { -> { described_class.parse_json(input) } }
+      subject(:parse_attempt) { described_class.parse_json(input) }
 
       it 'raises an error when the json fails to parse' do
-        expect { subject.call }.to raise_error do |err|
+        expect { subject }.to raise_error do |err|
           expect(err).to be_an_instance_of(BlockScore::Error)
           expect(err.message).to eql(error)
         end

--- a/spec/unit/block_score/util_spec.rb
+++ b/spec/unit/block_score/util_spec.rb
@@ -1,113 +1,111 @@
-module BlockScore
-  RSpec.describe Util do
-    shared_context 'a transform' do
-      subject(:actual) { described_class.send(method, input) }
-      it { should eql(output) }
+RSpec.describe BlockScore::Util do
+  shared_context 'a transform' do
+    subject(:actual) { described_class.send(method, input) }
+    it { should eql(output) }
+  end
+
+  describe '.to_plural' do
+    shared_context 'to_plural' do
+      let(:method) { :to_plural }
+      include_context 'a transform'
     end
 
-    describe '.to_plural' do
-      shared_context 'to_plural' do
-        let(:method) { :to_plural }
-        include_context 'a transform'
-      end
+    context 'candidate' do
+      let(:input) { 'candidate' }
+      let(:output) { 'candidates' }
 
-      context 'candidate' do
-        let(:input) { 'candidate' }
-        let(:output) { 'candidates' }
-
-        it_behaves_like 'to_plural'
-      end
-
-      context 'question_set' do
-        let(:input) { 'question_set' }
-        let(:output) { 'question_sets' }
-
-        it_behaves_like 'to_plural'
-      end
-
-      context 'company' do
-        let(:input) { 'company' }
-        let(:output) { 'companies' }
-
-        it_behaves_like 'to_plural'
-      end
-
-      context 'person' do
-        let(:input) { 'person' }
-        let(:output) { 'people' }
-
-        it_behaves_like 'to_plural'
-      end
-
-      context 'watchlist_hit' do
-        let(:input) { 'watchlist_hit' }
-        let(:output) { 'watchlist_hits' }
-
-        it_behaves_like 'to_plural'
-      end
+      it_behaves_like 'to_plural'
     end
 
-    describe '.to_camelcase' do
-      shared_context 'to_camelcase' do
-        let(:method) { :to_camelcase }
-        include_context 'a transform'
-      end
+    context 'question_set' do
+      let(:input) { 'question_set' }
+      let(:output) { 'question_sets' }
 
-      context 'screaming_snake_case' do
-        let(:input) { 'screaming_snake_case' }
-        let(:output) { 'ScreamingSnakeCase' }
-
-        it_behaves_like 'to_camelcase'
-      end
-
-      context 'snake_case' do
-        let(:input) { 'snake_case' }
-        let(:output) { 'SnakeCase' }
-
-        it_behaves_like 'to_camelcase'
-      end
-
-      context 'foo' do
-        let(:input) { 'foo' }
-        let(:output) { 'Foo' }
-
-        it_behaves_like 'to_camelcase'
-      end
-
-      context 'empty string' do
-        let(:input) { '' }
-        let(:output) { '' }
-
-        it_behaves_like 'to_camelcase'
-      end
+      it_behaves_like 'to_plural'
     end
 
-    describe '.parse_json' do
-      shared_context 'parse_json' do
-        let(:method) { :parse_json }
-        include_context 'a transform'
-      end
+    context 'company' do
+      let(:input) { 'company' }
+      let(:output) { 'companies' }
 
-      context 'valid input' do
-        let(:input) { output.to_json }
-        let(:output) { { foo: 'bar', baz: 'bat' } }
+      it_behaves_like 'to_plural'
+    end
 
-        it_behaves_like 'parse_json'
-      end
+    context 'person' do
+      let(:input) { 'person' }
+      let(:output) { 'people' }
 
-      context 'translates errors' do
-        let(:error) do
-          'An error has occurred. ' \
+      it_behaves_like 'to_plural'
+    end
+
+    context 'watchlist_hit' do
+      let(:input) { 'watchlist_hit' }
+      let(:output) { 'watchlist_hits' }
+
+      it_behaves_like 'to_plural'
+    end
+  end
+
+  describe '.to_camelcase' do
+    shared_context 'to_camelcase' do
+      let(:method) { :to_camelcase }
+      include_context 'a transform'
+    end
+
+    context 'screaming_snake_case' do
+      let(:input) { 'screaming_snake_case' }
+      let(:output) { 'ScreamingSnakeCase' }
+
+      it_behaves_like 'to_camelcase'
+    end
+
+    context 'snake_case' do
+      let(:input) { 'snake_case' }
+      let(:output) { 'SnakeCase' }
+
+      it_behaves_like 'to_camelcase'
+    end
+
+    context 'foo' do
+      let(:input) { 'foo' }
+      let(:output) { 'Foo' }
+
+      it_behaves_like 'to_camelcase'
+    end
+
+    context 'empty string' do
+      let(:input) { '' }
+      let(:output) { '' }
+
+      it_behaves_like 'to_camelcase'
+    end
+  end
+
+  describe '.parse_json' do
+    shared_context 'parse_json' do
+      let(:method) { :parse_json }
+      include_context 'a transform'
+    end
+
+    context 'valid input' do
+      let(:input) { output.to_json }
+      let(:output) { { foo: 'bar', baz: 'bat' } }
+
+      it_behaves_like 'parse_json'
+    end
+
+    context 'translates errors' do
+      let(:error) do
+        'An error has occurred. ' \
           'If this problem persists, please message support@blockscore.com.'
-        end
-        let(:input) { '{{' }
-        subject(:parse_attempt) { -> { described_class.parse_json(input) } }
+      end
+      let(:input) { '{{' }
+      subject(:parse_attempt) { -> { described_class.parse_json(input) } }
 
-        it 'raises an error when the json fails to parse' do
-          expect { subject.call }.to raise_error do |err|
-            expect(err).to be_an_instance_of(Error)
-            expect(err.message).to eql(error)
-          end
+      it 'raises an error when the json fails to parse' do
+        expect { subject.call }.to raise_error do |err|
+          expect(err).to be_an_instance_of(BlockScore::Error)
+          expect(err.message).to eql(error)
         end
       end
     end


### PR DESCRIPTION
- Refactor the headers in the unit tests to combine the module BlockScore into the Spec describe block to not pollute the underlying namespace
- The above change has two effects 1) dedenting the code (making it all marked as changed), and 2) requiring a correct directory name block_score not blockscore
- Thus all the unit test moved to unit/block_score and now all the files are deleted and added
- This had the side effect of meaning that the cassettes were also regenerated in most cases under a new directory path
- The errors which were arbitrarily under an errors sub-directory are now under block_score directory
- the above necessitated changing the exclusions in rubocop.yml but otherwise satisfied naming conventions in rubocop.

In addition to these global changes, there are many internal changes:

- spec code was shortened to eliminate max line length faults (BTW that means that rubocop exclusions need to be revisited - they are not automatically dropped)
- all cases of ' eq ' tests where promoted to eql or equal to strengthen assertions
- all be_a comparisons were strengthened to an appropriate be_an_instance_of
- described_class was inserted everywhere appropriate

Also some tests from the various member classes where pushed into a new Base_spec.rb as that is where the unit tests should reside (nb: base_spec.rb is incomplete and will be addressed in short-term future)

What is not done?

The cases of be_persisted, etc. should be changed to persisted? be true to strengthen the assertion of predicate methods returning true or false.
And of course once this is in place than another pass to ensure method coverage.
Addition of specific unit tests for the actions is also a to-do.