### PR TITLE
Correct vcr setup

### DIFF
--- a/spec/vcr_setup.rb
+++ b/spec/vcr_setup.rb
@@ -9,7 +9,7 @@ module BlockScore
   extend self
 
   RSpec.configure do |config|
-    config.before(:suite) do
+    config.before(:context) do
       BlockScore.api_key = ENV.fetch(ENVIRONMENT_API_KEY, PLACEHOLDER_API_KEY)
     end
 

--- a/spec/vcr_setup.rb
+++ b/spec/vcr_setup.rb
@@ -13,9 +13,11 @@ module BlockScore
       BlockScore.api_key = ENV.fetch(ENVIRONMENT_API_KEY, PLACEHOLDER_API_KEY)
     end
 
-    config.around(vcr: true) do |example|
+    config.around(:each) do |example|
       record_option = ENV.fetch(RECORD_MODE_KEY, :none).to_sym
-      BlockScore.run_vcr_example({ record: record_option }, example)
+      vcr_on = example.metadata.fetch(:vcr, false)
+      options = { record: (vcr_on ? record_option : :skip) }
+      BlockScore.run_vcr_example(options, example)
     end
   end
 


### PR DESCRIPTION
Since VCR needs to be explicitly turned off, the prior approach of just running without VCR is insufficient. VCR needs to be "skipped" along with full external network access re-enabled if vcr: true is missing. This commit fixes that, so with vcr true then the recording mode is fetched from environment variable (as was prior). If vcr: true is missing, then the recording mode is set to :skip which triggers the enablement of the network and VCR is explicitly turned off for that example.