### PR TITLE
Change "include_verification_steps" rule for PRs

### DIFF
--- a/contributing.json
+++ b/contributing.json
@@ -18,7 +18,7 @@
     "subject_must_start_with_case": "upper",
     "subject_must_not_end_with_dot": true,
     "body_cannot_be_empty": true,
-    "body_must_include_verification_steps": true
+    "body_must_include_verification_steps": false
   },
   "issue": {
     "subject_cannot_be_empty": true,


### PR DESCRIPTION
I'm removing the requirement for verification steps. This isn't currently part of our policy